### PR TITLE
[Proposal] Term and Literal inside of SomethingLike

### DIFF
--- a/lib/pact/consumer_contract/consumer_contract.rb
+++ b/lib/pact/consumer_contract/consumer_contract.rb
@@ -1,5 +1,6 @@
 require 'pact/logging'
 require 'pact/something_like'
+require 'pact/literal'
 require 'pact/symbolize_keys'
 require 'pact/term'
 require 'pact/shared/active_support_support'

--- a/lib/pact/helpers.rb
+++ b/lib/pact/helpers.rb
@@ -1,4 +1,5 @@
 require 'pact/something_like'
+require 'pact/literal'
 require 'pact/term'
 require 'pact/array_like'
 
@@ -23,6 +24,10 @@ module Pact
 
     def like content
       Pact::SomethingLike.new(content)
+    end
+
+    def literal(content)
+      Pact::Literal.new(content)
     end
 
     def each_like content, options = {}

--- a/lib/pact/literal.rb
+++ b/lib/pact/literal.rb
@@ -1,0 +1,41 @@
+require 'pact/symbolize_keys'
+
+module Pact
+  class Literal
+    include SymbolizeKeys
+
+    attr_reader :contents
+
+    def initialize(contents)
+      @contents = contents
+    end
+
+    def to_hash
+      { json_class: self.class.name, contents: contents }
+    end
+
+    def as_json(opts = {})
+      to_hash
+    end
+
+    def to_json(opts = {})
+      as_json.to_json(opts)
+    end
+
+    def self.json_create(hash)
+      new(symbolize_keys(hash)[:contents])
+    end
+
+    def eq(other)
+      self == other
+    end
+
+    def ==(other)
+      other.is_a?(self.class) && other.contents == self.contents
+    end
+
+    def generate
+      contents
+    end
+  end
+end

--- a/lib/pact/matchers/matchers.rb
+++ b/lib/pact/matchers/matchers.rb
@@ -37,7 +37,7 @@ module Pact
       when Hash then hash_diff(expected, actual, options)
       when Array then array_diff(expected, actual, options)
       when Regexp then regexp_diff(expected, actual, options)
-      when Pact::SomethingLike then calculate_diff(expected.contents, actual, options.merge(:type => true))
+      when Pact::SomethingLike then diff(expected.contents, actual, options.merge(type: true))
       when Pact::ArrayLike then array_like_diff(expected, actual, options)
       else object_diff(expected, actual, options)
       end
@@ -68,7 +68,7 @@ module Pact
       length.times do | index|
         expected_item = expected.fetch(index, Pact::UnexpectedIndex.new)
         actual_item = actual.fetch(index, Pact::IndexNotFound.new)
-        if (item_diff = calculate_diff(expected_item, actual_item, options)).any?
+        if (item_diff = diff(expected_item, actual_item, options)).any?
           diff_found = true
           difference << item_diff
         else
@@ -98,7 +98,7 @@ module Pact
 
     def actual_hash_diff expected, actual, options
       hash_diff = expected.each_with_object({}) do |(key, value), difference|
-        diff_at_key = calculate_diff(value, actual.fetch(key, Pact::KeyNotFound.new), options)
+        diff_at_key = diff(value, actual.fetch(key, Pact::KeyNotFound.new), options)
         difference[key] = diff_at_key if diff_at_key.any?
       end
       hash_diff.merge(check_for_unexpected_keys(expected, actual, options))

--- a/lib/pact/matchers/matchers.rb
+++ b/lib/pact/matchers/matchers.rb
@@ -1,6 +1,7 @@
 require 'awesome_print'
 require 'pact/term'
 require 'pact/something_like'
+require 'pact/literal'
 require 'pact/shared/null_expectation'
 require 'pact/shared/key_not_found'
 require 'pact/matchers/unexpected_key'
@@ -38,6 +39,7 @@ module Pact
       when Array then array_diff(expected, actual, options)
       when Regexp then regexp_diff(expected, actual, options)
       when Pact::SomethingLike then diff(expected.contents, actual, options.merge(type: true))
+      when Pact::Literal then diff(expected.contents, actual, options.merge(type: false))
       when Pact::ArrayLike then array_like_diff(expected, actual, options)
       else object_diff(expected, actual, options)
       end

--- a/lib/pact/matching_rules/extract.rb
+++ b/lib/pact/matching_rules/extract.rb
@@ -30,6 +30,7 @@ module Pact
         when Hash then recurse_hash(object, path, match_type)
         when Array then recurse_array(object, path, match_type)
         when Pact::SomethingLike then handle_something_like(object, path, match_type)
+        when Pact::Literal then handle_literal(object, path, match_type)
         when Pact::ArrayLike then handle_array_like(object, path, match_type)
         when Pact::Term then record_regex_rule object, path
         else
@@ -51,6 +52,10 @@ module Pact
 
       def handle_something_like something_like, path, match_type
         recurse something_like.contents, path, "type"
+      end
+
+      def handle_literal(literal, path, match_type)
+        recurse(literal.contents, path, "literal")
       end
 
       def handle_array_like array_like, path, match_type

--- a/lib/pact/matching_rules/extract.rb
+++ b/lib/pact/matching_rules/extract.rb
@@ -1,4 +1,5 @@
 require 'pact/something_like'
+require 'pact/literal'
 require 'pact/array_like'
 require 'pact/term'
 

--- a/lib/pact/matching_rules/merge.rb
+++ b/lib/pact/matching_rules/merge.rb
@@ -77,6 +77,8 @@ module Pact
 
         if rules['match'] == 'type'
           handle_match_type(object, path, rules)
+        elsif rules['match'] == 'literal'
+          handle_literal(object, path, rules)
         elsif rules['regex']
           handle_regex(object, path, rules)
         else
@@ -88,6 +90,11 @@ module Pact
       def handle_match_type object, path, rules
         log_ignored_rules(path, rules, {'match' => 'type'})
         Pact::SomethingLike.new(object)
+      end
+
+      def handle_literal(object, path, rules)
+        log_ignored_rules(path, rules, {'match' => 'literal'})
+        Pact::Literal.new(object)
       end
 
       def handle_regex object, path, rules

--- a/lib/pact/reification.rb
+++ b/lib/pact/reification.rb
@@ -8,7 +8,7 @@ module Pact
     def self.from_term(term)
       case term
       when Pact::Term, Regexp, Pact::SomethingLike, Pact::ArrayLike
-        term.generate
+        from_term(term.generate)
       when Hash
         term.inject({}) do |mem, (key,term)|
           mem[key] = from_term(term)

--- a/lib/pact/reification.rb
+++ b/lib/pact/reification.rb
@@ -7,7 +7,7 @@ module Pact
 
     def self.from_term(term)
       case term
-      when Pact::Term, Regexp, Pact::SomethingLike, Pact::ArrayLike
+      when Pact::Term, Regexp, Pact::SomethingLike, Pact::ArrayLike, Pact::Literal
         from_term(term.generate)
       when Hash
         term.inject({}) do |mem, (key,term)|

--- a/spec/integration/matching_rules_extract_and_merge_spec.rb
+++ b/spec/integration/matching_rules_extract_and_merge_spec.rb
@@ -96,4 +96,72 @@ describe "converting Pact::Term and Pact::SomethingLike to matching rules and ba
       expect(recreated_expected).to eq similar
     end
   end
+
+  context "with a Pact::Literal" do
+    let(:expected) do
+      {
+        body: {
+          alligator: {
+            name: Pact::Literal.new("Mary")
+          }
+        }
+      }
+    end
+
+    it "recreates the same object hierarchy" do
+      expect(recreated_expected).to eq expected
+    end
+  end
+
+  context "with Pact::SomethingLike containing Literal" do
+    let(:expected) do
+      {
+        body: Pact::SomethingLike.new(
+          foo: "bar",
+          alligator: {
+            name: Pact::Literal.new("Mary")
+          }
+        )
+      }
+    end
+
+    it "recreates the semantically same object" do
+      expect(recreated_expected).to eq(
+        {
+          body: {
+            foo: Pact::SomethingLike.new("bar"),
+            alligator: {
+              name: Pact::Literal.new("Mary")
+            }
+          }
+        }
+      )
+    end
+  end
+
+  context "with Pact::Literal containing SomethingLike" do
+    let(:expected) do
+      {
+        body: Pact::Literal.new(
+          foo: "bar",
+          alligator: {
+            name: Pact::SomethingLike.new("Mary")
+          }
+        )
+      }
+    end
+
+    it "recreates the semantically same object" do
+      expect(recreated_expected).to eq(
+        {
+          body: {
+            foo: Pact::Literal.new("bar"),
+            alligator: {
+              name: Pact::SomethingLike.new("Mary")
+            }
+          }
+        }
+      )
+    end
+  end
 end

--- a/spec/integration/matching_rules_extract_and_merge_spec.rb
+++ b/spec/integration/matching_rules_extract_and_merge_spec.rb
@@ -1,5 +1,6 @@
 require 'pact/term'
 require 'pact/something_like'
+require 'pact/literal'
 require 'pact/matching_rules/extract'
 require 'pact/matching_rules/merge'
 require 'pact/reification'

--- a/spec/lib/pact/helpers_spec.rb
+++ b/spec/lib/pact/helpers_spec.rb
@@ -38,6 +38,12 @@ module Pact
       end
     end
 
+    describe "#literal" do
+      it "creates a Pact::Literal" do
+        expect(literal(1)).to eq Pact::Literal.new(1)
+      end
+    end
+
     describe "#each_like" do
       it "creates a Pact::ArrayLike" do
         expect(each_like(1)).to eq Pact::ArrayLike.new(1)

--- a/spec/lib/pact/matchers/matchers_spec.rb
+++ b/spec/lib/pact/matchers/matchers_spec.rb
@@ -42,7 +42,6 @@ module Pact::Matchers
     end
 
     describe 'matching with something like' do
-
       context 'when the actual is something like the expected' do
         let(:expected) { Pact::SomethingLike.new( { a: 1 } ) }
         let(:actual) { { a: 2} }
@@ -50,9 +49,24 @@ module Pact::Matchers
         it 'returns an empty diff' do
           expect(diff(expected, actual)).to eq({})
         end
-
       end
 
+      context 'when Pact::SomethingLike including Pact::Term' do
+        let(:expected) { Pact::SomethingLike.new(a: 'A', b: Pact::Term.new(generate: 'B', matcher: /B\d?/)) }
+        let(:actual) { { a: 'X', b: 'B1' } }
+
+        it 'returns an empty diff' do
+          expect(diff(expected, actual)).to eq({})
+        end
+
+        context 'when the actual does not match' do
+          let(:actual) { { a: 'X', b: 'Y1' } }
+
+          it 'returns a diff' do
+            expect(diff(expected, actual)).to match(b: a_kind_of(Pact::Matchers::RegexpDifference))
+          end
+        end
+      end
     end
 
     describe 'option {allow_unexpected_keys: false}' do

--- a/spec/lib/pact/matchers/matchers_spec.rb
+++ b/spec/lib/pact/matchers/matchers_spec.rb
@@ -69,6 +69,43 @@ module Pact::Matchers
       end
     end
 
+    describe 'matching with literal' do
+      context 'when the actual is literally the expected' do
+        let(:expected) { Pact::Literal.new(a: 1) }
+        let(:actual) { { a: 1 } }
+
+        it 'returns an empty diff' do
+          expect(diff(expected, actual)).to eq({})
+        end
+      end
+
+      context 'when the actual is not literally the expected' do
+        let(:expected) { Pact::Literal.new(a: 1) }
+        let(:actual) { { a: 2 } }
+
+        it 'returns a diff' do
+          expect(diff(expected, actual)).to match(a: a_kind_of(Pact::Matchers::Difference))
+        end
+      end
+
+      context 'when Pact::Literal including Pact::Term' do
+        let(:expected) { Pact::Literal.new(a: 'A', b: Pact::Term.new(generate: 'B', matcher: /B\d?/)) }
+        let(:actual) { { a: 'A', b: 'B1' } }
+
+        it 'returns an empty diff' do
+          expect(diff(expected, actual)).to eq({})
+        end
+
+        context 'when the actual does not match' do
+          let(:actual) { { a: 'A', b: 'Y1' } }
+
+          it 'returns a diff' do
+            expect(diff(expected, actual)).to match(b: a_kind_of(Pact::Matchers::RegexpDifference))
+          end
+        end
+      end
+    end
+
     describe 'option {allow_unexpected_keys: false}' do
       context "when an unexpected key is found" do
         let(:expected) { {:a => 1} }

--- a/spec/lib/pact/matching_rules/extract_spec.rb
+++ b/spec/lib/pact/matching_rules/extract_spec.rb
@@ -31,6 +31,25 @@ module Pact
           end
         end
 
+        context "with a Pact::Literal" do
+          let(:matchable) do
+            {
+              body: Pact::Literal.new(foo: 'bar', alligator: { name: 'Mary' })
+            }
+          end
+
+          let(:rules) do
+            {
+              "$.body.foo" => {"match" => "literal"},
+              "$.body.alligator.name" => {"match" => "literal"},
+            }
+          end
+
+          it "does not create any rules" do
+            expect(subject).to eq rules
+          end
+        end
+
         context "with a Pact::Term" do
           let(:matchable) do
             {
@@ -71,6 +90,50 @@ module Pact
           end
 
           it "the match:regex overrides the match:type" do
+            expect(subject).to eq rules
+          end
+        end
+
+        context "with a Pact::SomethingLike containing a Literal" do
+          let(:matchable) do
+            {
+              body: Pact::SomethingLike.new(
+                foo: 'bar',
+                alligator: { name: Pact::Literal.new('Mary') }
+              )
+            }
+          end
+
+          let(:rules) do
+            {
+              "$.body.foo" => {"match" => "type"},
+              "$.body.alligator.name" => {"match" => "literal"},
+            }
+          end
+
+          it "does not create any rules at the path" do
+            expect(subject).to eq rules
+          end
+        end
+
+        context "with a Pact::Literal containing a SomethingLike" do
+          let(:matchable) do
+            {
+              body: Pact::Literal.new(
+                foo: 'bar',
+                alligator: { name: Pact::SomethingLike.new('Mary') }
+              )
+            }
+          end
+
+          let(:rules) do
+            {
+              "$.body.foo" => {"match" => "literal"},
+              "$.body.alligator.name" => {"match" => "type"},
+            }
+          end
+
+          it "creates match:type rule at the path" do
             expect(subject).to eq rules
           end
         end

--- a/spec/lib/pact/matching_rules/extract_spec.rb
+++ b/spec/lib/pact/matching_rules/extract_spec.rb
@@ -1,5 +1,6 @@
 require 'pact/matching_rules/extract'
 require 'pact/something_like'
+require 'pact/literal'
 require 'pact/array_like'
 require 'pact/term'
 

--- a/spec/lib/pact/matching_rules/merge_spec.rb
+++ b/spec/lib/pact/matching_rules/merge_spec.rb
@@ -86,6 +86,29 @@ module Pact
 
       end
 
+      describe "literal matching" do
+        let(:expected) do
+          {
+            "name" => "Mary"
+          }
+        end
+
+        let(:matching_rules) do
+          {
+            "$.body.name" => { "match" => "literal", "ignored" => "matchingrule" }
+          }
+        end
+
+        it "creates a Literal at the appropriate path" do
+          expect(subject['name']).to be_instance_of(Pact::Literal)
+        end
+
+        it "logs the rules it has ignored" do
+          expect($stderr).to receive(:puts).with(/ignored.*matchingrule/)
+          subject
+        end
+      end
+
       describe "regular expressions" do
 
         describe "in a hash" do

--- a/spec/lib/pact/reification_spec.rb
+++ b/spec/lib/pact/reification_spec.rb
@@ -70,6 +70,24 @@ module Pact
       end
     end
 
+    context "when Literal" do
+      let(:request) { Pact::Literal.new(a: 'String') }
+      subject { Reification.from_term(request) }
+
+      it "returns the contents of the Literal" do
+        expect(subject).to eq(a: 'String')
+      end
+
+      context "including term" do
+        let(:request) { Pact::Literal.new(a: 'A', b: Pact::Term.new(generate: 'B', matcher: /./)) }
+        subject { Reification.from_term(request) }
+
+        it "returns the contents with reification" do
+          expect(subject[:b]).to eq('B')
+        end
+      end
+    end
+
     context "when ArrayLike" do
 
       let(:request) { Pact::ArrayLike.new({a: 'String'}, {min: 3})}

--- a/spec/lib/pact/reification_spec.rb
+++ b/spec/lib/pact/reification_spec.rb
@@ -52,7 +52,6 @@ module Pact
     end
 
     context "when SomethingLike" do
-
       let(:request) { Pact::SomethingLike.new({a: 'String'})}
 
       subject { Reification.from_term(request)}
@@ -61,6 +60,14 @@ module Pact
         expect(subject).to eq({a: 'String'})
       end
 
+      context "including term" do
+        let(:request) { Pact::SomethingLike.new(a: 'A', b: Pact::Term.new(generate: 'B', matcher: /./)) }
+        subject { Reification.from_term(request) }
+
+        it "returns the contents with reification" do
+          expect(subject[:b]).to eq('B')
+        end
+      end
     end
 
     context "when ArrayLike" do


### PR DESCRIPTION
Since I am a newbie of Pact, I don't know this kind of changes can be acceptable or not which seem to change both pact specification v1 and v2. But I want this kind of features to save time and effort to write expectations. How about?

Literal originally comes from this gist https://gist.github.com/bethesque/5a35a3c1cb9fdab6dce7. But I changed behavior that Literal can contain SomethingLike again and it triggers type matching again. The reason is composability of parts of expectation. For example by below expectation, we can extract `media` object by using `let` in RSpec, and re-use and put into other object (like `user` object or `recipe` object) even if parent object is wrapped by Literal.

---

Sometimes we face a large JSON object in API response, and
Consumer-Driven Contract can be large about the same as the response.
In this case, we might writes lots of `Pact.like` to build expectation
with Pact DSL:

``` ruby
{
  id: like(1),
  name: like("Special seafood curry"),
  created_at: like_datetime("2016-01-01T16:51:18+09:00"),
  published_at: like_datetime("2016-03-01T16:51:18+09:00"),
  description: like("this is my favorite recipe."),
  media: {
    mime_type: like("image/jpeg"),
    original: term(generate: "https://example.com/recipe.jpg", matchers: /XXX/),
    thumbnail: term(generate: "https://example.com/recipe_thumb.jpg", matchers: /XXX/),
    # ...
  },
  # ...
}
```

By this change, we can wrap whole expectation by SomethingLike, then
apply Term at points:

``` ruby
Pact.like(
  id: 1,
  name: "Special seafood curry",
  created_at: like_datetime("2016-01-01T16:51:18+09:00"),
  published_at: like_datetime("2016-03-01T16:51:18+09:00"),
  # ...
)
```

This saves time to write expectation and keep readability.

---

As same as the patch which allows SomethingLike to contain Terms, this
saves time to write expectation and keep readability when we write the
expectation having combination of lots of SomethingLike and a few of
exact matching:

``` ruby
{
  id: like(1),
  name: "Special seafood curry", # Exact matching here
  description: like("this is my favorite recipe."),
  media: {
    mime_type: "image/jpeg",
    original: term(generate: "https://example.com/recipe.jpg", matchers: /XXX/),
    thumbnail: term(generate: "https://example.com/recipe_thumb.jpg", matchers: /XXX/),
    # ...
  },
  # Lots of like matching...
}
```

By this change, we can apply exact matching at points:

``` ruby
Pact.like(
  id: 1,
  name: literal("Special seafood curry"),
  description: "this is my favorite recipe.",
  # ...
)
```

We can let Literal inside of SomethingLike contain SomethingLike again,
and it means type matching resumes inside of the nested SomethingLike.
