### PR TITLE
Add support to match integers and floats

### DIFF
--- a/lib/pact/term.rb
+++ b/lib/pact/term.rb
@@ -24,9 +24,11 @@ module Pact
 
     def initialize(attributes = {})
       @generate = attributes[:generate]
+      raise "Please specify a value to generate for the Term" unless @generate != nil
+      
+      @generate = @generate.to_s 
       @matcher = attributes[:matcher]
       raise "Please specify a matcher for the Term" unless @matcher != nil
-      raise "Please specify a value to generate for the Term" unless @generate != nil
       raise "Value to generate \"#{@generate}\" does not match regular expression #{@matcher.inspect}" unless @generate =~ @matcher
     end
 

--- a/spec/lib/pact/term_spec.rb
+++ b/spec/lib/pact/term_spec.rb
@@ -14,6 +14,22 @@ module Pact
           end
         end
 
+        context "when the generate is a integer" do
+          let(:term) { Term.new(generate: 10, matcher: /[0-9]/)} 
+
+          it 'does not raise an exception' do
+            term
+          end 
+        end
+        
+        context "when the generate is a float" do
+          let(:term) { Term.new(generate: 50.51, matcher: /\d(\.\d{1,2})/)} 
+
+          it 'does not raise an exception' do
+            term
+          end 
+        end
+
         context "when the matcher does not match the generated value" do
           let(:generate) { 'banana' }
           it 'raises an exception' do


### PR DESCRIPTION
The main idea here is to able to match integer/float values, not only strings.

It helps to validate more fields in the pact expectations, if necessary.