### PR TITLE
Travis: jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.1.8
   - 2.2.4
   - 2.3.1
-  - jruby-9.0.5.0
+  - jruby-9.1.13.0
 gemfile:
   - gemfiles/default.gemfile
   - gemfiles/ruby_under_22.gemfile
@@ -19,5 +19,5 @@ matrix:
       gemfile: gemfiles/ruby_under_22.gemfile
     - rvm: 2.3.1
       gemfile: gemfiles/ruby_under_22.gemfile
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/ruby_under_22.gemfile


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html