### PR TITLE
Gemspec: Try using FakeFS 0.11.2

### DIFF
--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 10.0.3'
   gem.add_development_dependency 'webmock', '~> 2.0.0'
   gem.add_development_dependency 'pry'
-  gem.add_development_dependency 'fakefs', '0.11.1'
+  gem.add_development_dependency 'fakefs', '0.11.2'
   gem.add_development_dependency 'hashie', '~> 2.0'
   gem.add_development_dependency 'activesupport'
   gem.add_development_dependency 'appraisal'

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 10.0.3'
   gem.add_development_dependency 'webmock', '~> 2.0.0'
   gem.add_development_dependency 'pry'
-  gem.add_development_dependency 'fakefs', '0.5.2' #0.5.3+ breaks everything
+  gem.add_development_dependency 'fakefs', '0.11.1'
   gem.add_development_dependency 'hashie', '~> 2.0'
   gem.add_development_dependency 'activesupport'
   gem.add_development_dependency 'appraisal'

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 10.0.3'
   gem.add_development_dependency 'webmock', '~> 2.0.0'
   gem.add_development_dependency 'pry'
-  gem.add_development_dependency 'fakefs', '0.11.2'
+  gem.add_development_dependency 'fakefs', '~> 0.11.2'
   gem.add_development_dependency 'hashie', '~> 2.0'
   gem.add_development_dependency 'activesupport'
   gem.add_development_dependency 'appraisal'


### PR DESCRIPTION
This PR is related to a change in Pact, which led to a failure when used with JRuby 9.1.13.0.

The [gemspec](https://github.com/pact-foundation/pact-support/blob/master/pact-support.gemspec), has pegged fakefs to `0.5.2`:

```
  gem.add_development_dependency 'fakefs', '0.5.2' #0.5.3+ breaks everything
```

[FakeFS 0.5.2 code is from 2014](https://github.com/fakefs/fakefs/releases/tag/v0.5.2).

This commit added that line: https://github.com/pact-foundation/pact-support/commit/9bba528bca17c4650eb135fb35b5b23df72feb67

Perhaps a newer fakefs would make things... better? 

https://github.com/fakefs/fakefs/releases/tag/v0.11.2

See https://github.com/realestate-com-au/pact/pull/144