### PR TITLE
README: use foundation build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pact Support
 
-[![Build Status](https://travis-ci.org/bethesque/pact-support.svg?branch=master)](https://travis-ci.org/bethesque/pact-support)
+[![Build Status](https://travis-ci.org/pact-foundation/pact-support.svg?branch=master)](https://travis-ci.org/pact-foundation/pact-support)
 
 Provides shared code for the Pact gems


### PR DESCRIPTION
This PR changes the Travis build badge to the one not for the personal repository, but to the one on `pact-foundation`. 

Speculation: this repo was moved and the badge link was not updated.

Hope this helps!