### PR TITLE
Fix Ruby 2.5 warnings

### DIFF
--- a/lib/pact/configuration.rb
+++ b/lib/pact/configuration.rb
@@ -72,8 +72,8 @@ module Pact
 
     # Should this be deprecated in favour of register_diff_formatter???
     def diff_formatter= diff_formatter
-      register_diff_formatter /.*/, diff_formatter
-      register_diff_formatter nil, diff_formatter
+      register_diff_formatter(/.*/, diff_formatter)
+      register_diff_formatter(nil, diff_formatter)
     end
 
     def register_diff_formatter content_type, diff_formatter

--- a/lib/pact/consumer_contract/consumer_contract.rb
+++ b/lib/pact/consumer_contract/consumer_contract.rb
@@ -34,7 +34,7 @@ module Pact
       new(
         :consumer => ServiceConsumer.from_hash(hash[:consumer]),
         :provider => ServiceProvider.from_hash(hash[:provider]),
-        :interactions => hash[:interactions].collect { |hash| Interaction.from_hash(hash)}
+        :interactions => hash[:interactions].collect { |h| Interaction.from_hash(h)}
       )
     end
 

--- a/lib/pact/consumer_contract/query_string.rb
+++ b/lib/pact/consumer_contract/query_string.rb
@@ -1,5 +1,4 @@
 require 'pact/shared/active_support_support'
-require 'pact/matchers'
 
 module Pact
   class QueryString

--- a/lib/pact/matchers/matchers.rb
+++ b/lib/pact/matchers/matchers.rb
@@ -224,7 +224,7 @@ module Pact
           expected_desc = class_name_with_value_in_brackets(expected)
           expected_desc.gsub!("(", "(like ")
           actual_desc = class_name_with_value_in_brackets(actual)
-          message = "Expected #{expected_desc} but got #{actual_desc} at <path>"
+          "Expected #{expected_desc} but got #{actual_desc} at <path>"
         end
       end
     end

--- a/lib/pact/matching_rules/jsonpath.rb
+++ b/lib/pact/matching_rules/jsonpath.rb
@@ -13,7 +13,6 @@ module Pact
       def initialize(path)
         scanner = StringScanner.new(path)
         @path = []
-        bracket_count = 0
         while not scanner.eos?
           if token = scanner.scan(/\$/)
             @path << token

--- a/lib/pact/matching_rules/jsonpath.rb
+++ b/lib/pact/matching_rules/jsonpath.rb
@@ -48,10 +48,10 @@ module Pact
             @path.last << token
           end
         end
+      end
 
-        def to_s
-          path.join
-        end
+      def to_s
+        path.join
       end
     end
   end

--- a/lib/pact/reification.rb
+++ b/lib/pact/reification.rb
@@ -15,8 +15,8 @@ module Pact
       when Pact::Term, Regexp, Pact::SomethingLike, Pact::ArrayLike
         from_term(term.generate)
       when Hash
-        term.inject({}) do |mem, (key,term)|
-          mem[key] = from_term(term)
+        term.inject({}) do |mem, (key,t)|
+          mem[key] = from_term(t)
           mem
         end
       when Array

--- a/lib/pact/shared/form_differ.rb
+++ b/lib/pact/shared/form_differ.rb
@@ -1,4 +1,3 @@
-require 'pact/matchers/matchers'
 require 'uri'
 
 module Pact

--- a/lib/pact/shared/form_differ.rb
+++ b/lib/pact/shared/form_differ.rb
@@ -19,8 +19,8 @@ module Pact
     end
 
     def self.ensure_values_are_arrays hash
-      hash.each_with_object({}) do | (key, value), hash |
-        hash[key.to_s] = [*value]
+      hash.each_with_object({}) do | (key, value), h |
+        h[key.to_s] = [*value]
       end
     end
 

--- a/lib/pact/shared/json_differ.rb
+++ b/lib/pact/shared/json_differ.rb
@@ -1,5 +1,3 @@
-require 'pact/matchers/matchers'
-
 module Pact
   class JsonDiffer
 

--- a/lib/pact/shared/request.rb
+++ b/lib/pact/shared/request.rb
@@ -1,4 +1,3 @@
-require 'pact/matchers'
 require 'pact/symbolize_keys'
 require 'pact/consumer_contract/headers'
 require 'pact/consumer_contract/query'

--- a/lib/pact/shared/text_differ.rb
+++ b/lib/pact/shared/text_differ.rb
@@ -1,4 +1,3 @@
-require 'pact/matchers/matchers'
 require 'pact/matchers/difference'
 
 module Pact


### PR DESCRIPTION
I noticed a number of warnings from this lib when working with a Ruby 2.5 project. When running the tests here, the first thing I noticed is that the test suite cannot be run currently on 2.5 (Fixnum -> Integer change is a big violator, also problems in `spec/lib/pact/consumer_contract/pact_file_spec.rb`).

Anyway, I figured it wouldn't hurt to at least address the warnings that I'm seeing. I went pragmatic on each one, so variable names are pretty week and I'm not 💯 on the circular reference fixes.

Let me know what you think! Thanks 💫 