### PR TITLE
Build against Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.1.8
   - 2.2.4
   - 2.3.1
+  - 2.4.3
+  - 2.5.0
   - jruby-9.1.13.0
 gemfile:
   - gemfiles/default.gemfile
@@ -18,6 +20,10 @@ matrix:
     - rvm: 2.2.4
       gemfile: gemfiles/ruby_under_22.gemfile
     - rvm: 2.3.1
+      gemfile: gemfiles/ruby_under_22.gemfile
+    - rvm: 2.4.3
+      gemfile: gemfiles/ruby_under_22.gemfile
+    - rvm: 2.5.0
       gemfile: gemfiles/ruby_under_22.gemfile
     - rvm: jruby-9.1.13.0
       gemfile: gemfiles/ruby_under_22.gemfile

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'awesome_print', '~> 1.1'
 
   gem.add_development_dependency 'rake', '~> 10.0.3'
-  gem.add_development_dependency 'webmock', '~> 2.0.0'
+  gem.add_development_dependency 'webmock', '~> 3.3'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'fakefs', '~> 0.11.2'
   gem.add_development_dependency 'hashie', '~> 2.0'

--- a/spec/lib/pact/matchers/list_diff_formatter_spec.rb
+++ b/spec/lib/pact/matchers/list_diff_formatter_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'pact/matchers/list_diff_formatter'
 require 'pact/matchers/matchers'
+require 'support/ruby_version_helpers'
 
 # Needed to stop the ai printing in color
 # TODO: fix this!
@@ -23,7 +24,7 @@ module Pact
 \tExpected type:
 \t\tString
 \tActual type:
-\t\tFixnum
+\t\t#{RubyVersionHelpers.numeric_type}
 EOS
           }
 

--- a/spec/lib/pact/matchers/matchers_messages_mismatched_value_spec.rb
+++ b/spec/lib/pact/matchers/matchers_messages_mismatched_value_spec.rb
@@ -1,11 +1,13 @@
 require 'spec_helper'
 require 'pact/matchers'
 require 'pact/consumer_contract/headers'
+require 'support/ruby_version_helpers'
 
 module Pact::Matchers
 
   describe Pact::Matchers do
     include Pact::Matchers
+    extend RubyVersionHelpers
 
     describe "diff" do
       STRING = "foo"
@@ -23,7 +25,7 @@ module Pact::Matchers
         [STRING, ARRAY, "Expected \"foo\" but got an Array at <path>"],
         [Pact.like(STRING), "bar", nil],
         [Pact.like(STRING), nil, "Expected a String (like \"foo\") but got nil at <path>"],
-        [Pact.like(STRING), INT, "Expected a String (like \"foo\") but got a Fixnum (1) at <path>"],
+        [Pact.like(STRING), INT, "Expected a String (like \"foo\") but got #{a_numeric} (1) at <path>"],
         [Pact.like(STRING), FLOAT, "Expected a String (like \"foo\") but got a Float (1.0) at <path>"],
         [Pact.like(STRING), HASH, "Expected a String (like \"foo\") but got a Hash at <path>"],
         [Pact.like(STRING), ARRAY, "Expected a String (like \"foo\") but got an Array at <path>"],
@@ -34,22 +36,22 @@ module Pact::Matchers
         [INT, HASH, "Expected 1 but got a Hash at <path>"],
         [INT, ARRAY, "Expected 1 but got an Array at <path>"],
         [Pact.like(INT), 2, nil],
-        [Pact.like(INT), nil, "Expected a Fixnum (like 1) but got nil at <path>"],
-        [Pact.like(INT), STRING, "Expected a Fixnum (like 1) but got a String (\"foo\") at <path>"],
-        [Pact.like(INT), FLOAT, "Expected a Fixnum (like 1) but got a Float (1.0) at <path>"],
-        [Pact.like(INT), HASH, "Expected a Fixnum (like 1) but got a Hash at <path>"],
-        [Pact.like(INT), ARRAY, "Expected a Fixnum (like 1) but got an Array at <path>"],
+        [Pact.like(INT), nil, "Expected #{a_numeric} (like 1) but got nil at <path>"],
+        [Pact.like(INT), STRING, "Expected #{a_numeric} (like 1) but got a String (\"foo\") at <path>"],
+        [Pact.like(INT), FLOAT, "Expected #{a_numeric} (like 1) but got a Float (1.0) at <path>"],
+        [Pact.like(INT), HASH, "Expected #{a_numeric} (like 1) but got a Hash at <path>"],
+        [Pact.like(INT), ARRAY, "Expected #{a_numeric} (like 1) but got an Array at <path>"],
         [HASH, HASH, nil],
         [HASH, nil, "Expected a Hash but got nil at <path>"],
         [HASH, STRING, "Expected a Hash but got a String (\"foo\") at <path>"],
-        [HASH, INT, "Expected a Hash but got a Fixnum (1) at <path>"],
+        [HASH, INT, "Expected a Hash but got #{a_numeric} (1) at <path>"],
         [HASH, FLOAT, "Expected a Hash but got a Float (1.0) at <path>"],
         [HASH, ARRAY, "Expected a Hash but got an Array at <path>"],
         [Pact.like(HASH), STRING, "Expected a Hash but got a String (\"foo\") at <path>"],
         [ARRAY, ARRAY, nil],
         [ARRAY, nil, "Expected an Array but got nil at <path>"],
         [ARRAY, STRING, "Expected an Array but got a String (\"foo\") at <path>"],
-        [ARRAY, INT, "Expected an Array but got a Fixnum (1) at <path>"],
+        [ARRAY, INT, "Expected an Array but got #{a_numeric} (1) at <path>"],
         [ARRAY, FLOAT, "Expected an Array but got a Float (1.0) at <path>"],
         [ARRAY, HASH, "Expected an Array but got a Hash at <path>"]
       ]

--- a/spec/lib/pact/matchers/matchers_messages_regexp_spec.rb
+++ b/spec/lib/pact/matchers/matchers_messages_regexp_spec.rb
@@ -1,11 +1,13 @@
 require 'spec_helper'
 require 'pact/matchers'
 require 'pact/consumer_contract/headers'
+require 'support/ruby_version_helpers'
 
 module Pact::Matchers
 
   describe Pact::Matchers do
     include Pact::Matchers
+    include RubyVersionHelpers
 
     describe "diff" do
       STRING = "foo"
@@ -29,10 +31,10 @@ module Pact::Matchers
           end
         end
 
-        context "when the actual is a Fixnum" do
+        context "when the actual is a numeric" do
           let(:actual) { INT }
           it "returns a message" do
-            expect(difference[:thing].message).to eq "Expected a String matching /foo/ (like \"food\") but got a Fixnum (1) at <path>"
+            expect(difference[:thing].message).to eq "Expected a String matching /foo/ (like \"food\") but got #{a_numeric} (1) at <path>"
           end
         end
 
@@ -43,10 +45,10 @@ module Pact::Matchers
           end
         end
 
-        context "when the actual is a Fixnum" do
+        context "when the actual is a numeric" do
           let(:actual) { INT }
           it "returns a message" do
-            expect(difference[:thing].message).to eq "Expected a String matching /foo/ (like \"food\") but got a Fixnum (1) at <path>"
+            expect(difference[:thing].message).to eq "Expected a String matching /foo/ (like \"food\") but got #{a_numeric} (1) at <path>"
           end
         end
 
@@ -68,10 +70,10 @@ module Pact::Matchers
           end
         end
 
-        context "when the actual is a Fixnum" do
+        context "when the actual is a numeric" do
           let(:actual) { INT }
           it "returns a message" do
-            expect(difference[:thing].message).to eq "Expected a String matching /foo/ but got a Fixnum (1) at <path>"
+            expect(difference[:thing].message).to eq "Expected a String matching /foo/ but got #{a_numeric} (1) at <path>"
           end
         end
 
@@ -82,10 +84,10 @@ module Pact::Matchers
           end
         end
 
-        context "when the actual is a Fixnum" do
+        context "when the actual is a numeric" do
           let(:actual) { INT }
           it "returns a message" do
-            expect(difference[:thing].message).to eq "Expected a String matching /foo/ but got a Fixnum (1) at <path>"
+            expect(difference[:thing].message).to eq "Expected a String matching /foo/ but got #{a_numeric} (1) at <path>"
           end
         end
 

--- a/spec/lib/pact/matchers/type_difference_spec.rb
+++ b/spec/lib/pact/matchers/type_difference_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 require 'pact/matchers/type_difference'
+require 'support/ruby_version_helpers'
 
 module Pact
   module Matchers
     describe TypeDifference do
+      include RubyVersionHelpers
 
       describe "#as_json" do
 
@@ -21,7 +23,7 @@ module Pact
         end
 
         context "when the actual is an ActualType" do
-          let(:expected_hash) { {:EXPECTED_TYPE => "String", :ACTUAL_TYPE => "Fixnum" } }
+          let(:expected_hash) { {:EXPECTED_TYPE => "String", :ACTUAL_TYPE => numeric_type.to_s } }
 
           it "uses the key ACTUAL_TYPE" do
              expect(subject.as_json).to eq(expected_hash)

--- a/spec/lib/pact/matchers/unix_diff_formatter_spec.rb
+++ b/spec/lib/pact/matchers/unix_diff_formatter_spec.rb
@@ -2,10 +2,12 @@ require 'spec_helper'
 require 'pact/matchers/unix_diff_formatter'
 require 'pact/matchers/expected_type'
 require 'pact/matchers/actual_type'
+require 'support/ruby_version_helpers'
 
 module Pact
   module Matchers
     describe UnixDiffFormatter do
+      include RubyVersionHelpers
 
       describe ".call" do
 
@@ -35,7 +37,7 @@ module Pact
           let(:output) { <<-EOF
  {
 -  "thing": String
-+  "thing": Fixnum
++  "thing": #{numeric_type}
  }
 EOF
           }

--- a/spec/support/ruby_version_helpers.rb
+++ b/spec/support/ruby_version_helpers.rb
@@ -1,0 +1,23 @@
+module RubyVersionHelpers
+  RUBY_2_4 = Gem::Version.new('2.4.0')
+  CURRENT_RUBY = Gem::Version.new(RUBY_VERSION)
+
+  def numeric_type
+    if CURRENT_RUBY < RUBY_2_4
+      Fixnum
+    else
+      Integer
+    end
+  end
+  module_function :numeric_type
+
+  def a_numeric
+    type = numeric_type
+    if type == Integer
+      "an #{type}"
+    else
+      "a #{type}"
+    end
+  end
+  module_function :a_numeric
+end


### PR DESCRIPTION
Per discussion in #53, this PR updates the app to build against Ruby 2.5. Unfortunately I don't think there is a clean way to have it build against both 2.3 _and_ 2.5, i.e. I expect the versions < 2.4 to fail at the moment.

If we do want to have the build matrix run against all the listed versions, then we might have to do some version detection in the test suite to tailor its assertions.

Anyway, just starting the conversation here. Hopefully this is helpful!