### PR TITLE
Ignore the 'combine' key in matching rules

### DIFF
--- a/lib/pact/matching_rules/v3/merge.rb
+++ b/lib/pact/matching_rules/v3/merge.rb
@@ -111,6 +111,7 @@ module Pact
             ((rules_array.length - 1)..0).each do | index |
               rules_array.delete_at(index) if rules_array[index].empty?
             end
+            rules_hash.tap{ |hs| hs.delete("combine") }
           end
 
           if @matching_rules.any?

--- a/spec/fixtures/pact-http-v3.json
+++ b/spec/fixtures/pact-http-v3.json
@@ -17,7 +17,8 @@
         "matchingRules": {
           "body": {
             "$.foo": {
-              "matchers": [{ "match": "type" }]
+              "matchers": [{ "match": "type" }],
+              "combine": "AND"
             }
           }
         },


### PR DESCRIPTION
Verifing a pact produced by pact-jvm in V3 format it fails with this error:
```
pact-support-1.8.0/lib/pact/matching_rules/v3/merge.rb:124:in `block (2 levels) in log_ignored_rules': undefined method `any?' for "AND":String (NoMethodError)
```

it fails because the matching rules contain the `combine` key
```"$.assignedTimeSlot": {
      "matchers": [ { "match": "type" } ],
      "combine": "AND"
}```

in order to make it works again I remove the `combine` key from the hash because it is not relevant to log the unsupported matcher
