### PR TITLE
[WIP] feat: add query params to request path

### DIFF
--- a/lib/pact/consumer_contract/interaction_v2_parser.rb
+++ b/lib/pact/consumer_contract/interaction_v2_parser.rb
@@ -14,8 +14,7 @@ module Pact
     def self.call hash, options
       if hash['request'].has_key? 'query'
       params = Rack::Utils.parse_nested_query(hash['request']['query'])
-      query = URI.encode_www_form(params)
-      hash['request']['path'] = hash['request']['path'] << '?' << query
+      hash['request']['query'] = params
       end
       request = parse_request(hash['request'], options)
       response = parse_response(hash['response'], options)

--- a/lib/pact/consumer_contract/interaction_v2_parser.rb
+++ b/lib/pact/consumer_contract/interaction_v2_parser.rb
@@ -4,6 +4,7 @@ require 'pact/consumer_contract/provider_state'
 require 'pact/symbolize_keys'
 require 'pact/matching_rules'
 require 'pact/errors'
+require 'rack/utils'
 
 module Pact
   class InteractionV2Parser
@@ -11,6 +12,11 @@ module Pact
     include SymbolizeKeys
 
     def self.call hash, options
+      if hash['request'].has_key? 'query'
+      params = Rack::Utils.parse_nested_query(hash['request']['query'])
+      query = URI.encode_www_form(params)
+      hash['request']['path'] = hash['request']['path'] << '?' << query
+      end
       request = parse_request(hash['request'], options)
       response = parse_response(hash['response'], options)
       provider_states = parse_provider_states(hash['providerState'] || hash['provider_state'])

--- a/spec/lib/pact/consumer_contract/interaction_v2_parser_spec.rb
+++ b/spec/lib/pact/consumer_contract/interaction_v2_parser_spec.rb
@@ -61,7 +61,7 @@ module Pact
         {
           "description" => "description",
           "request" => { "method" => "GET", "path" => "/" ,
-            "query" => 'param1=thing1&param2=thing2'},
+          "query" => 'param1=thing1&param2=thing2'},
           "response" => { "status" => 200 },
           "providerState" => "foo"
         }
@@ -79,6 +79,32 @@ module Pact
         it "encodes them as a hash" do
           expect(subject.request.query).to include :param1 => ["thing1"]
           expect(subject.request.query).to include :param2 => ["thing2"]
+        end
+      end
+    end
+    describe ".call with 2 of the same query params but with diff values" do
+      let(:interaction_hash) do
+        {
+          "description" => "description",
+          "request" => { "method" => "GET", "path" => "/" ,
+          "query" => 'param1=thing1&param1=thing2'},
+          "response" => { "status" => 200 },
+          "providerState" => "foo"
+        }
+      end
+
+      let(:options) do
+        {
+          pact_specification_version: Pact::SpecificationVersion.new("3.0")
+        }
+      end
+
+      subject { InteractionV2Parser.call(interaction_hash, options) }
+
+      describe "query params" do
+        it "encodes them as a hash" do
+          expect(subject.request.query).to include :param1 => ["thing1"]
+          expect(subject.request.query).to include :param1 => ["thing2"]
         end
       end
     end

--- a/spec/lib/pact/consumer_contract/interaction_v2_parser_spec.rb
+++ b/spec/lib/pact/consumer_contract/interaction_v2_parser_spec.rb
@@ -49,6 +49,38 @@ module Pact
           expect(subject.provider_state).to eq "foo"
         end
       end
+
+      describe "no query params" do
+        it "doesnt add query params if they dont exist" do
+          expect(subject.request.query).to_not eq ''
+        end
+      end
+    end
+    describe ".call with query params" do
+      let(:interaction_hash) do
+        {
+          "description" => "description",
+          "request" => { "method" => "GET", "path" => "/" ,
+            "query" => 'param1=thing1&param2=thing2'},
+          "response" => { "status" => 200 },
+          "providerState" => "foo"
+        }
+      end
+
+      let(:options) do
+        {
+          pact_specification_version: Pact::SpecificationVersion.new("3.0")
+        }
+      end
+
+      subject { InteractionV2Parser.call(interaction_hash, options) }
+
+      describe "query params" do
+        it "encodes them as a hash" do
+          expect(subject.request.query).to include :param1 => ["thing1"]
+          expect(subject.request.query).to include :param2 => ["thing2"]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Initial stab at https://github.com/pact-foundation/pact-mock_service/issues/80

> Background: the reason the query is a string in the pact is that initially, we threw away all the matching information and only stored the "actual" reified request in the pact (because the matching that takes place in the mock service was already done, and the stub service didn't exist at that stage). Later, we realised the matching info was useful info, so we added it in, as it was just an addition to the json, and would be ignored by the pact verification step. Changing the query string from a string to a hash would be a breaking change for the v2 specification, however. The code on the other side expects a string and not a hash. In v3, it has been changed to a hash, but only the v3 pact reading code has been done in the ruby, (and only the format change, not new features are supported) not the v3 writing code.
> 
> Here is the code that parses the v2 request, and merges the matching rules into the request structure to create a tree of nested matchers. https://github.com/pact-foundation/pact-support/blob/master/lib/pact/consumer_contract/interaction_v2_parser.rb
> 
> We're going to have to parse the query string, if it exists, and overwrite it in the request hash before it gets parsed into the `Pact::MatchingRules.merge` (incidentally, this will fix another issue we get about the matching rules not being applied correctly to the string query, when the rules are expecting a hash query!). The code for parsing the query is `Rack::Utils.parse_nested_query(query_string)`. It'll make the code a bit ugly, but sometimes you've got to do what you've got to do!



Hey @bethesque 

started looking at this now, based on your comments, I am assuming your after something like

in `lib/pact/consumer_contract/interaction_v2_parser.rb`

we need to 

1. check if a query exists and if it does, then
2. parse it into a hash of params
3. convert it into a string
4. add it to `hash['request']`
5. call `request = parse_request(hash['request'], options)`

Been playing around and this is where I've got to
 
```
def self.call hash, options
      # Parse the query string assuming
      #         'request' => {
      #           'path' => '/path',
      #           'method' => 'get',
      #           'query' => 'param=thing&param2=blah'
      #         },
      if hash['request'].has_key? 'query'
      params = Rack::Utils.parse_nested_query(hash['request']['query'])
      # {"param"=>"thing", "param2"=>"blah"}
      query = URI.encode_www_form(params)
      # param=thing&param2=blah
      hash['request']['path'] = hash['request']['path'] << '?' << query
      # /path?param=thing&param2=blah
      end
      request = parse_request(hash['request'], options)
      response = parse_response(hash['response'], options)
      provider_states = parse_provider_states(hash['providerState'] || hash['provider_state'])
      Interaction.new(symbolize_keys(hash).merge(request: request, response: response, provider_states: provider_states))
    end
```

Hopefully I am on the right track? 