### PR TITLE
Support marking an interaction as writable/not writable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ reports
 Gemfile.lock
 gemfiles/*.lock
 spec/examples.txt
+.byebug_history

--- a/lib/pact/consumer_contract/consumer_contract.rb
+++ b/lib/pact/consumer_contract/consumer_contract.rb
@@ -86,7 +86,10 @@ module Pact
       interactions.reject do |interaction|
         # For the sake of backwards compatibility, only reject interactions where 
         # write_to_pact is explicitly set to false
-        interaction&.metadata&.[](:write_to_pact) == false
+        interaction.respond_to?(:metadata) && 
+          !interaction.metadata.nil? && 
+          interaction.metadata.key?(:write_to_pact) &&
+          interaction.metadata[:write_to_pact] == false
       end
     end
 

--- a/lib/pact/consumer_contract/consumer_contract.rb
+++ b/lib/pact/consumer_contract/consumer_contract.rb
@@ -82,5 +82,13 @@ module Pact
       end
     end
 
+    def writable_interactions
+      interactions.reject do |interaction|
+        # For the sake of backwards compatibility, only reject interactions where 
+        # write_to_pact is explicitly set to false
+        interaction&.metadata&.[](:write_to_pact) == false
+      end
+    end
+
   end
 end

--- a/lib/pact/consumer_contract/interaction.rb
+++ b/lib/pact/consumer_contract/interaction.rb
@@ -5,7 +5,7 @@ module Pact
   class Interaction
     include ActiveSupportSupport
 
-    attr_accessor :description, :request, :response, :provider_state, :provider_states
+    attr_accessor :description, :request, :response, :provider_state, :provider_states, :metadata
 
     def initialize attributes = {}
       @description = attributes[:description]
@@ -13,6 +13,7 @@ module Pact
       @response = attributes[:response]
       @provider_state = attributes[:provider_state] || attributes[:providerState]
       @provider_states = attributes[:provider_states]
+      @metadata = attributes[:metadata]
     end
 
     def self.from_hash hash, options = {}
@@ -30,6 +31,7 @@ module Pact
 
       h[:request] = request.to_hash
       h[:response] = response.to_hash
+      h[:metadata] = metadata
       h
     end
 

--- a/lib/pact/consumer_contract/interaction_v2_parser.rb
+++ b/lib/pact/consumer_contract/interaction_v2_parser.rb
@@ -14,7 +14,11 @@ module Pact
       request = parse_request(hash['request'], options)
       response = parse_response(hash['response'], options)
       provider_states = parse_provider_states(hash['providerState'] || hash['provider_state'])
-      Interaction.new(symbolize_keys(hash).merge(request: request, response: response, provider_states: provider_states))
+      metadata = parse_metadata(hash['metadata'])
+      Interaction.new(symbolize_keys(hash).merge(request: request, 
+                                                 response: response, 
+                                                 provider_states: provider_states,
+                                                 metadata: metadata))
     end
 
     def self.parse_request request_hash, options
@@ -29,6 +33,10 @@ module Pact
 
     def self.parse_provider_states provider_state_name
       provider_state_name ? [Pact::ProviderState.new(provider_state_name)] : []
+    end
+
+    def self.parse_metadata metadata_hash
+      symbolize_keys(metadata_hash)
     end
   end
 end

--- a/lib/pact/consumer_contract/interaction_v3_parser.rb
+++ b/lib/pact/consumer_contract/interaction_v3_parser.rb
@@ -19,7 +19,12 @@ module Pact
       if provider_states && provider_states.size > 1
         Pact.configuration.error_stream.puts("WARN: Currently only 1 provider state is supported. Ignoring ")
       end
-      Interaction.new(symbolize_keys(hash).merge(request: request, response: response, provider_states: provider_states, provider_state: provider_state))
+      metadata = parse_metadata(hash['metadata'])
+      Interaction.new(symbolize_keys(hash).merge(request: request, 
+                                                 response: response, 
+                                                 provider_states: provider_states, 
+                                                 provider_state: provider_state,
+                                                 metadata: metadata))
     end
 
     def self.parse_request request_hash, options
@@ -68,6 +73,10 @@ module Pact
       (provider_states || []).collect do | provider_state_hash |
         Pact::ProviderState.new(provider_state_hash['name'], provider_state_hash['params'])
       end
+    end
+
+    def self.parse_metadata metadata_hash
+      symbolize_keys(metadata_hash)
     end
   end
 end

--- a/spec/lib/pact/consumer_contract/consumer_contract_spec.rb
+++ b/spec/lib/pact/consumer_contract/consumer_contract_spec.rb
@@ -147,10 +147,10 @@ module Pact
       let(:interaction4) { double('Pact::Interaction') }
       
       before do
-        expect(interaction1).to receive(:metadata).and_return(write_to_pact: false)
-        expect(interaction2).to receive(:metadata).and_return(write_to_pact: true)
-        expect(interaction3).to receive(:metadata).and_return(some_other_key: :some_value)
-        expect(interaction4).to receive(:metadata).and_return(nil)
+        allow(interaction1).to receive(:metadata).and_return(write_to_pact: false)
+        allow(interaction2).to receive(:metadata).and_return(write_to_pact: true)
+        allow(interaction3).to receive(:metadata).and_return(some_other_key: :some_value)
+        allow(interaction4).to receive(:metadata).and_return(nil)
       end
 
       subject { ConsumerContract.new(:interactions => [interaction1, interaction2, interaction3, interaction4], :consumer => consumer, :provider => provider) }

--- a/spec/lib/pact/consumer_contract/consumer_contract_spec.rb
+++ b/spec/lib/pact/consumer_contract/consumer_contract_spec.rb
@@ -138,5 +138,27 @@ module Pact
       end
     end
 
+    describe "#writable_interactions" do
+      let(:consumer) { double('Pact::ServiceConsumer', :name => 'Consumer')}
+      let(:provider) { double('Pact::ServiceProvider', :name => 'Provider')}
+      let(:interaction1) { double('Pact::Interaction') }
+      let(:interaction2) { double('Pact::Interaction') }
+      let(:interaction3) { double('Pact::Interaction') }
+      let(:interaction4) { double('Pact::Interaction') }
+      
+      before do
+        expect(interaction1).to receive(:metadata).and_return(write_to_pact: false)
+        expect(interaction2).to receive(:metadata).and_return(write_to_pact: true)
+        expect(interaction3).to receive(:metadata).and_return(some_other_key: :some_value)
+        expect(interaction4).to receive(:metadata).and_return(nil)
+      end
+
+      subject { ConsumerContract.new(:interactions => [interaction1, interaction2, interaction3, interaction4], :consumer => consumer, :provider => provider) }
+      context "when one interaction is not writable" do
+        it "returns only the writable interactions" do
+          expect(subject.writable_interactions.size).to eql 3
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
1) Added a `metadata` attribute to the `Interaction` class to pass metadata at the interaction level.
2) Added a `#writable_interactions` method to `ConsumerContract` which returns the list of contract interactions after filtering out interactions that have `write_to_pact` set to false in their metadata.