### PR TITLE
refactor: clean up Pact v3 specs

### DIFF
--- a/spec/lib/pact/matching_rules/v3/extract_spec.rb
+++ b/spec/lib/pact/matching_rules/v3/extract_spec.rb
@@ -1,237 +1,229 @@
 require 'pact/matching_rules/v3/extract'
-require 'pact/support'
 
-module Pact
-  module MatchingRules::V3
-    describe Extract do
+describe Pact::MatchingRules::V3::Extract do
+  describe ".call" do
+    subject { described_class.call(matchable) }
 
-      describe ".call" do
+    context "with a Pact::SomethingLike" do
+      let(:matchable) do
+        {
+          body: Pact::SomethingLike.new(foo: 'bar', alligator: { name: 'Mary' })
+        }
+      end
 
-        subject { Extract.call(matchable) }
+      let(:rules) do
+        {
+          "$.body" => {
+            "matchers" => [ {"match" => "type"} ]
+          }
+        }
+      end
 
-        context "with a Pact::SomethingLike" do
-          let(:matchable) do
-            {
-              body: Pact::SomethingLike.new(foo: 'bar', alligator: { name: 'Mary' })
+      it "creates a rule that matches by type" do
+        expect(subject).to eq rules
+      end
+    end
+
+    context "with a Pact::Term" do
+      let(:matchable) do
+        {
+          body: {
+            alligator: {
+              name: Pact::Term.new(generate: 'Mary', matcher: /.*a/)
             }
-          end
+          }
+        }
+      end
 
-          let(:rules) do
-            {
-              "$.body" => {
-                "matchers" => [ {"match" => "type"} ]
-              }
-            }
-          end
+      let(:rules) do
+        {
+          "$.body.alligator.name" => {
+            "matchers" => [ {"match" => "regex", "regex" => ".*a"} ]
+          }
+        }
+      end
 
-          it "creates a rule that matches by type" do
-            expect(subject).to eq rules
-          end
-        end
+      it "creates a rule that matches by regex" do
+        expect(subject).to eq rules
+      end
+    end
 
-        context "with a Pact::Term" do
-          let(:matchable) do
-            {
-              body: {
-                alligator: {
-                  name: Pact::Term.new(generate: 'Mary', matcher: /.*a/)
-                }
-              }
-            }
-          end
+    context "with a Pact::SomethingLike containing a Term" do
+      let(:matchable) do
+        {
+          body: Pact::SomethingLike.new(
+            foo: 'bar',
+            alligator: { name: Pact::Term.new(generate: 'Mary', matcher: /.*a/) }
+          )
+        }
+      end
 
-          let(:rules) do
-            {
-              "$.body.alligator.name" => {
-                "matchers" => [ {"match" => "regex", "regex" => ".*a"} ]
-              }
-            }
-          end
+      let(:rules) do
+        {
+          "$.body" => {
+            "matchers" => [ {"match" => "type"} ]
+          },
+          "$.body.alligator.name" => {
+            "matchers" => [ {"match" => "regex", "regex"=>".*a"} ]
+          },
+        }
+      end
 
-          it "creates a rule that matches by regex" do
-            expect(subject).to eq rules
-          end
-        end
+      it "the match:regex overrides the match:type" do
+        expect(subject).to eq rules
+      end
+    end
 
-        context "with a Pact::SomethingLike containing a Term" do
-          let(:matchable) do
-            {
-              body: Pact::SomethingLike.new(
-                foo: 'bar',
-                alligator: { name: Pact::Term.new(generate: 'Mary', matcher: /.*a/) }
-              )
-            }
-          end
+    context "with a Pact::SomethingLike containing an array" do
+      let(:matchable) do
+        {
+          body: Pact::SomethingLike.new(
+            alligators: [
+              {name: 'Mary'},
+              {name: 'Betty'}
+            ]
+          )
+        }
+      end
 
-          let(:rules) do
-            {
-              "$.body" => {
-                "matchers" => [ {"match" => "type"} ]
-              },
-              "$.body.alligator.name" => {
-                "matchers" => [ {"match" => "regex", "regex"=>".*a"} ]
-              },
-            }
-          end
+      let(:rules) do
+        {
+          "$.body" => {
+            "matchers" => [ {"match" => "type"} ]
+          }
+        }
+      end
 
-          it "the match:regex overrides the match:type" do
-            expect(subject).to eq rules
-          end
-        end
+      it "lists a rule for each item" do
+        expect(subject).to eq rules
+      end
+    end
 
-        context "with a Pact::SomethingLike containing an array" do
-          let(:matchable) do
-            {
-              body: Pact::SomethingLike.new(
-                alligators: [
-                  {name: 'Mary'},
-                  {name: 'Betty'}
-                ]
-              )
-            }
-          end
+    context "with an ArrayLike" do
+      let(:matchable) do
+        {
+          body: {
+            alligators: Pact::ArrayLike.new(
+              name: 'Fred'
+            )
+          }
+        }
+      end
 
-          let(:rules) do
-            {
-              "$.body" => {
-                "matchers" => [ {"match" => "type"} ]
-              }
-            }
-          end
+      let(:rules) do
+        {
+          "$.body.alligators" => {
+            "matchers" => [ {"min" => 1} ]
+          },
+          "$.body.alligators[*].*" => {
+            "matchers" => [ {"match" => "type"} ]
+          }
+        }
+      end
 
-          it "lists a rule for each item" do
-            expect(subject).to eq rules
-          end
-        end
+      it "lists a rule for all items" do
+        expect(subject).to eq rules
+      end
+    end
 
-        context "with an ArrayLike" do
-          let(:matchable) do
-            {
-              body: {
-                alligators: Pact::ArrayLike.new(
-                  name: 'Fred'
-                )
-              }
-            }
-          end
+    context "with an ArrayLike with a Pact::Term inside" do
+      let(:matchable) do
+        {
+          body: {
+            alligators: Pact::ArrayLike.new(
+              name: 'Fred',
+              phoneNumber: Pact::Term.new(generate: '1234567', matcher: /\d+/)
+            )
+          }
+        }
+      end
 
-          let(:rules) do
-            {
-              "$.body.alligators" => {
-                "matchers" => [ {"min" => 1} ]
-              },
-              "$.body.alligators[*].*" => {
-                "matchers" => [ {"match" => "type"} ]
-              }
-            }
-          end
+      let(:rules) do
+        {
+          "$.body.alligators" => {
+            "matchers" => [ {"min" => 1} ]
+          },
+          "$.body.alligators[*].*" => {
+            "matchers" => [ {"match" => "type"} ]
+          },
+          "$.body.alligators[*].phoneNumber" => {
+            "matchers" => [ {"match" => "regex", "regex" => "\\d+"} ]
+          }
+        }
+      end
 
-          it "lists a rule for all items" do
-            expect(subject).to eq rules
-          end
-        end
+      it "lists a rule that specifies that the regular expression must match" do
+        expect(subject).to eq rules
+      end
+    end
 
-        context "with an ArrayLike with a Pact::Term inside" do
-          let(:matchable) do
-            {
-              body: {
-                alligators: Pact::ArrayLike.new(
-                  name: 'Fred',
-                  phoneNumber: Pact::Term.new(generate: '1234567', matcher: /\d+/)
-                )
-              }
-            }
-          end
+    context "with a Pact::QueryString containing a Pact::Term" do
+      let(:matchable) do
+        {
+          query: Pact::QueryString.new(Pact::Term.new(generate: 'foobar', matcher: /foo/))
+        }
+      end
 
-          let(:rules) do
-            {
-              "$.body.alligators" => {
-                "matchers" => [ {"min" => 1} ]
-                },
-              "$.body.alligators[*].*" => {
-                "matchers" => [ {"match" => "type"} ]
-                },
-              "$.body.alligators[*].phoneNumber" => {
-                "matchers" => [ {"match" => "regex", "regex" => "\\d+"} ]
-              }
-            }
-          end
+      let(:rules) do
+        {
+          "$.query" => {
+            "matchers" => [ {"match" => "regex", "regex" => "foo"} ]
+          }
+        }
+      end
 
-          it "lists a rule that specifies that the regular expression must match" do
-            expect(subject).to eq rules
-          end
-        end
+      it "lists a rule that specifies that the regular expression must match" do
+        expect(subject).to eq rules
+      end
+    end
 
-        context "with a Pact::QueryString containing a Pact::Term" do
-          let(:matchable) do
-            {
-              query: Pact::QueryString.new(Pact::Term.new(generate: 'foobar', matcher: /foo/))
-            }
-          end
+    context "with a Pact::QueryHash containing a Pact::Term" do
+      let(:matchable) do
+        {
+          query: Pact::QueryHash.new(bar: Pact::Term.new(generate: 'foobar', matcher: /foo/))
+        }
+      end
 
-          let(:rules) do
-            {
-              "$.query" => {
-                "matchers" => [ {"match" => "regex", "regex" => "foo"} ]
-              }
-            }
-          end
+      let(:rules) do
+        {
+          "$.query.bar[0]" => {
+            "matchers" => [ {"match" => "regex", "regex" => "foo"} ]
+          }
+        }
+      end
 
-          it "lists a rule that specifies that the regular expression must match" do
-            expect(subject).to eq rules
-          end
-        end
+      it "lists a rule that specifies that the regular expression must match" do
+        expect(subject).to eq rules
+      end
+    end
 
-        context "with a Pact::QueryHash containing a Pact::Term" do
-          let(:matchable) do
-            {
-              query: Pact::QueryHash.new(bar: Pact::Term.new(generate: 'foobar', matcher: /foo/))
-            }
-          end
+    context "with no special matching" do
+      let(:matchable) do
+        {
+          body: { alligator: { name: 'Mary' } }
+        }
+      end
 
-          let(:rules) do
-            {
-              "$.query.bar[0]" => {
-                "matchers" => [ {"match" => "regex", "regex" => "foo"} ]
-              }
-            }
-          end
+      let(:rules) do
+        {}
+      end
 
-          it "lists a rule that specifies that the regular expression must match" do
-            expect(subject).to eq rules
-          end
-        end
+      it "does not create any rules" do
+        expect(subject).to eq rules
+      end
+    end
 
-        context "with no special matching" do
-          let(:matchable) do
-            {
-              body: { alligator: { name: 'Mary' } }
-            }
-          end
+    context "with a key containing a dot" do
+      let(:matchable) do
+        {
+          "key" => {
+            "key.with.dots" => Pact::SomethingLike.new("foo")
+          }
+        }
+      end
 
-          let(:rules) do
-            {}
-          end
-
-
-          it "does not create any rules" do
-            expect(subject).to eq rules
-          end
-        end
-
-        context "with a key containing a dot" do
-          let(:matchable) do
-            {
-              "key" => {
-                "key.with.dots" => Pact::SomethingLike.new("foo")
-              }
-            }
-          end
-
-          it "uses square brackets notation for the key with dots" do
-            expect(subject.keys).to include "$.key['key.with.dots']"
-          end
-        end
+      it "uses square brackets notation for the key with dots" do
+        expect(subject.keys).to include "$.key['key.with.dots']"
       end
     end
   end

--- a/spec/lib/pact/matching_rules/v3/merge_spec.rb
+++ b/spec/lib/pact/matching_rules/v3/merge_spec.rb
@@ -1,484 +1,493 @@
 require 'pact/matching_rules/v3/merge'
 
-module Pact
-  module MatchingRules
-    module V3
-      describe Merge do
-        subject { Merge.(expected, matching_rules) }
+describe Pact::MatchingRules::V3::Merge do
+  describe ".call" do
+    subject { described_class.call(expected, matching_rules) }
 
+    before do
+      allow($stderr).to receive(:puts) do |message|
+        raise <<-EOS
+                Was not expecting stderr to receive #{message.inspect} in this spec.
+                This may be because of a missed rule deletion in Merge.
+              EOS
+      end
+    end
+
+    context "no recognised rules" do
+      before do
+        allow($stderr).to receive(:puts)
+      end
+
+      let(:expected) do
+        {
+          "_links" => {
+            "self" => {
+              "href" => "http://localhost:1234/thing"
+            }
+          }
+        }
+      end
+
+      let(:matching_rules) do
+        {
+          "$._links.self.href" => {
+            "matchers" => [{ "type" => "unknown" }]
+          }
+        }
+      end
+
+      it "returns the object at that path unaltered" do
+        expect(subject["_links"]["self"]["href"]).to eq "http://localhost:1234/thing"
+      end
+
+      it "logs the rules it has ignored" do
+        subject
+
+        expect($stderr).to have_received(:puts) do |message|
+          expect(message).to include("WARN")
+            .and include("type")
+            .and include("unknown")
+            .and include("$['_links']")
+        end
+      end
+    end
+
+    context "with nil rules" do
+      let(:expected) do
+        {
+          "_links" => {
+            "self" => {
+              "href" => "http://localhost:1234/thing"
+            }
+          }
+        }
+      end
+
+      let(:matching_rules) { nil }
+
+      it "returns the example unaltered" do
+        expect(subject["_links"]["self"]["href"]).to eq "http://localhost:1234/thing"
+      end
+    end
+
+    context "type based matching" do
+      before do
+        allow($stderr).to receive(:puts)
+      end
+
+      let(:expected) do
+        {
+          "name" => "Mary"
+        }
+      end
+
+      let(:matching_rules) do
+        {
+          "$.name" => {
+            "matchers" => [{ "match" => "type", "ignored" => "matchingrule" }]
+          }
+        }
+      end
+
+      it "creates a SomethingLike at the appropriate path" do
+        expect(subject['name']).to be_instance_of(Pact::SomethingLike)
+      end
+
+      it "it logs the rules it has ignored" do
+        subject
+
+        expect($stderr).to have_received(:puts).once.with(/ignored.*matchingrule/)
+      end
+
+      it "does not alter the passed in rules hash" do
+        original_matching_rules = JSON.parse(matching_rules.to_json)
+        subject
+        expect(matching_rules).to eq original_matching_rules
+      end
+    end
+
+    context "when a Pact.like is nested inside a Pact.each_like which is nested inside a Pact.like" do
+      let(:original_definition) do
+        Pact.like('foos' => Pact.each_like(Pact.like('name' => "foo1")))
+      end
+
+      let(:expected) do
+        Pact::Reification.from_term(original_definition)
+      end
+
+      let(:matching_rules) do
+        Pact::MatchingRules::V3::Extract.call(original_definition)
+      end
+
+      it "creates a Pact::SomethingLike containing a Pact::ArrayLike containing a Pact::SomethingLike" do
+        expect(subject.to_hash).to eq original_definition.to_hash
+      end
+    end
+
+    context "when a Pact.array_like is the top level object" do
+      let(:original_definition) do
+        Pact.each_like('foos')
+      end
+
+      let(:expected) do
+        Pact::Reification.from_term(original_definition)
+      end
+
+      let(:matching_rules) do
+        Pact::MatchingRules::V3::Extract.call(original_definition)
+      end
+
+      it "creates a Pact::ArrayLike" do
+        expect(subject.to_hash).to eq original_definition.to_hash
+      end
+    end
+
+    context "when a Pact.like containing an array is the top level object" do
+      let(:original_definition) do
+        Pact.like(['foos'])
+      end
+
+      let(:expected) do
+        Pact::Reification.from_term(original_definition)
+      end
+
+      let(:matching_rules) do
+        Pact::MatchingRules::V3::Extract.call(original_definition)
+      end
+
+      it "creates a Pact::SomethingLike" do
+        expect(subject).to be_a(Pact::SomethingLike)
+        expect(subject.to_hash).to eq original_definition.to_hash
+      end
+    end
+
+    describe "regular expressions" do
+      context "in a hash" do
         before do
-          allow($stderr).to receive(:puts) do | message |
-            raise "Was not expecting stderr to receive #{message.inspect} in this spec. This may be because of a missed rule deletion in Merge."
-          end
+          allow($stderr).to receive(:puts)
         end
 
-        describe "no recognised rules" do
-          before do
-            allow($stderr).to receive(:puts)
-          end
-
-          let(:expected) do
-            {
-              "_links" => {
-                "self" => {
-                  "href" => "http://localhost:1234/thing"
-                }
+        let(:expected) do
+          {
+            "_links" => {
+              "self" => {
+                "href" => "http://localhost:1234/thing"
               }
             }
-          end
-
-          let(:matching_rules) do
-            {
-              "$._links.self.href" => {
-                "matchers" => [{ "type" => "unknown" }]
-              }
-            }
-          end
-
-          it "returns the object at that path unaltered" do
-            expect(subject["_links"]["self"]["href"]).to eq "http://localhost:1234/thing"
-          end
-
-          it "it logs the rules it has ignored" do
-            expect($stderr).to receive(:puts) do | message |
-              expect(message).to include("WARN")
-              expect(message).to include("type")
-              expect(message).to include("unknown")
-              expect(message).to include("$['_links']")
-            end
-            subject
-          end
-
+          }
         end
 
-        describe "with nil rules" do
-          let(:expected) do
-            {
-              "_links" => {
-                "self" => {
-                  "href" => "http://localhost:1234/thing"
-                }
-              }
+        let(:matching_rules) do
+          {
+            "$._links.self.href" => {
+              "matchers" => [{
+                "regex" => "http:\\/\\/.*\\/thing",
+                "match" => "regex",
+                "ignored" => "somerule"
+              }]
             }
-          end
-
-          let(:matching_rules) { nil }
-
-          it "returns the example unaltered" do
-            expect(subject["_links"]["self"]["href"]).to eq "http://localhost:1234/thing"
-          end
-
+          }
         end
 
-        describe "type based matching" do
-          before do
-            allow($stderr).to receive(:puts)
-          end
-
-          let(:expected) do
-            {
-              "name" => "Mary"
-            }
-          end
-
-          let(:matching_rules) do
-            {
-              "$.name" => {
-                "matchers" => [{ "match" => "type", "ignored" => "matchingrule" }]
-              }
-            }
-          end
-
-          it "creates a SomethingLike at the appropriate path" do
-            expect(subject['name']).to be_instance_of(Pact::SomethingLike)
-          end
-
-          it "it logs the rules it has ignored" do
-            expect($stderr).to receive(:puts).once.with(/ignored.*matchingrule/)
-            subject
-          end
-
-          it "does not alter the passed in rules hash" do
-            original_matching_rules = JSON.parse(matching_rules.to_json)
-            subject
-            expect(matching_rules).to eq original_matching_rules
-          end
+        it "creates a Pact::Term at the appropriate path" do
+          expect(subject["_links"]["self"]["href"]).to be_instance_of(Pact::Term)
+          expect(subject["_links"]["self"]["href"].generate).to eq "http://localhost:1234/thing"
+          expect(subject["_links"]["self"]["href"].matcher.inspect).to eq "/http:\\/\\/.*\\/thing/"
         end
 
-        describe "when a Pact.like is nested inside a Pact.each_like which is nested inside a Pact.like" do
-          let(:original_definition) do
-            Pact.like('foos' => Pact.each_like(Pact.like('name' => "foo1")))
-          end
+        it "logs the rules it has ignored" do
+          subject
 
-          let(:expected) do
-            Pact::Reification.from_term(original_definition)
-          end
-
-          let(:matching_rules) do
-            Extract.call(original_definition)
-          end
-
-          it "creates a Pact::SomethingLike containing a Pact::ArrayLike containing a Pact::SomethingLike" do
-            expect(subject.to_hash).to eq original_definition.to_hash
+          expect($stderr).to have_received(:puts) do |message|
+            expect(message).to match(/ignored.*"somerule"/)
+            expect(message).to_not match(/regex/)
+            expect(message).to_not match(/"match"/)
           end
         end
+      end
 
-        describe "when a Pact.array_like is the top level object" do
-          let(:original_definition) do
-            Pact.each_like('foos')
-          end
-
-          let(:expected) do
-            Pact::Reification.from_term(original_definition)
-          end
-
-          let(:matching_rules) do
-            Extract.call(original_definition)
-          end
-
-          it "creates a Pact::ArrayLike" do
-            expect(subject.to_hash).to eq original_definition.to_hash
-          end
+      context "with an array" do
+        let(:expected) do
+          {
+            "_links" => {
+              "self" => [{
+                "href" => "http://localhost:1234/thing"
+              }]
+            }
+          }
         end
 
-        describe "when a Pact.like containing an array is the top level object" do
-          let(:original_definition) do
-            Pact.like(['foos'])
-          end
-
-          let(:expected) do
-            Pact::Reification.from_term(original_definition).tap { |it| puts it }
-          end
-
-          let(:matching_rules) do
-            Extract.call(original_definition).tap { |it| puts it }
-          end
-
-          it "creates a Pact::SomethingLike" do
-            expect(subject).to be_a(Pact::SomethingLike)
-            expect(subject.to_hash).to eq original_definition.to_hash
-          end
+        let(:matching_rules) do
+          {
+            "$._links.self[0].href" => {
+              "matchers" => [{ "regex" => "http:\\/\\/.*\\/thing" }]
+            }
+          }
         end
 
-        describe "regular expressions" do
-          describe "in a hash" do
-            before do
-              allow($stderr).to receive(:puts)
-            end
+        it "creates a Pact::Term at the appropriate path" do
+          expect(subject["_links"]["self"][0]["href"]).to be_instance_of(Pact::Term)
+          expect(subject["_links"]["self"][0]["href"].generate).to eq "http://localhost:1234/thing"
+          expect(subject["_links"]["self"][0]["href"].matcher.inspect).to eq "/http:\\/\\/.*\\/thing/"
+        end
+      end
 
-            let(:expected) do
-              {
-                "_links" => {
-                  "self" => {
-                    "href" => "http://localhost:1234/thing"
-                  }
-                }
-              }
-            end
-
-            let(:matching_rules) do
-              {
-                "$._links.self.href" => {
-                  "matchers" => [{ "regex" => "http:\\/\\/.*\\/thing", "match" => "regex", "ignored" => "somerule" }]
-                }
-              }
-            end
-
-            it "creates a Pact::Term at the appropriate path" do
-              expect(subject["_links"]["self"]["href"]).to be_instance_of(Pact::Term)
-              expect(subject["_links"]["self"]["href"].generate).to eq "http://localhost:1234/thing"
-              expect(subject["_links"]["self"]["href"].matcher.inspect).to eq "/http:\\/\\/.*\\/thing/"
-            end
-
-            it "it logs the rules it has ignored" do
-              expect($stderr).to receive(:puts) do | message |
-                expect(message).to match /ignored.*"somerule"/
-                expect(message).to_not match /regex/
-                expect(message).to_not match /"match"/
-              end
-              subject
-            end
-          end
-
-          describe "with an array" do
-
-            let(:expected) do
-              {
-                "_links" => {
-                  "self" => [{
-                      "href" => "http://localhost:1234/thing"
-                  }]
-                }
-              }
-            end
-
-            let(:matching_rules) do
-              {
-                "$._links.self[0].href" => {
-                  "matchers" => [{ "regex" => "http:\\/\\/.*\\/thing" }]
-                }
-              }
-            end
-
-            it "creates a Pact::Term at the appropriate path" do
-              expect(subject["_links"]["self"][0]["href"]).to be_instance_of(Pact::Term)
-              expect(subject["_links"]["self"][0]["href"].generate).to eq "http://localhost:1234/thing"
-              expect(subject["_links"]["self"][0]["href"].matcher.inspect).to eq "/http:\\/\\/.*\\/thing/"
-            end
-          end
-
-          describe "with an ArrayLike containing a Term" do
-            let(:expected) do
-              ["foo"]
-            end
-
-            let(:matching_rules) do
-              {
-                "$" => {"matchers" => [{"min" => 1}]},
-                "$[*].*" => {"matchers" => [{"match" => "type"}]},
-                "$[*]" => {"matchers" => [{"match" => "regex", "regex"=>"f"}]}
-              }
-            end
-
-            it "it creates an ArrayLike with a Pact::Term as the contents" do
-              expect(subject).to be_a(Pact::ArrayLike)
-              expect(subject.contents).to be_a(Pact::Term)
-            end
-          end
+      describe "with an ArrayLike containing a Term" do
+        let(:expected) do
+          ["foo"]
         end
 
-        describe "with an array where all elements should match by type and the rule is specified on the parent element and there is no min specified" do
-          let(:expected) do
-            {
-              'alligators' => [{'name' => 'Mary'}]
-            }
-          end
-
-          let(:matching_rules) do
-            {
-              "$.alligators" => {
-                "matchers" => [{ 'match' => 'type' }]
-              }
-            }
-          end
-
-          it "creates a Pact::SomethingLike at the appropriate path" do
-            expect(subject["alligators"]).to be_instance_of(Pact::SomethingLike)
-            expect(subject["alligators"].contents).to eq ['name' => 'Mary']
-          end
+        let(:matching_rules) do
+          {
+            "$" => {"matchers" => [{"min" => 1}]},
+            "$[*].*" => {"matchers" => [{"match" => "type"}]},
+            "$[*]" => {"matchers" => [{"match" => "regex", "regex"=>"f"}]}
+          }
         end
 
-        describe "with an array where all elements should match by type and the rule is specified on the child elements" do
-          let(:expected) do
-            {
-              'alligators' => [{'name' => 'Mary'}]
-            }
-          end
-
-          let(:matching_rules) do
-            {
-              "$.alligators" => {
-                "matchers" => [{ 'min' => 2}]
-              },
-              "$.alligators[*].*" => {
-                "matchers" => [{ 'match' => 'type'}]
-              }
-            }
-          end
-          it "creates a Pact::ArrayLike at the appropriate path" do
-            expect(subject["alligators"]).to be_instance_of(Pact::ArrayLike)
-            expect(subject["alligators"].contents).to eq 'name' => 'Mary'
-            expect(subject["alligators"].min).to eq 2
-          end
+        it "creates an ArrayLike with a Pact::Term as the contents" do
+          expect(subject).to be_a(Pact::ArrayLike)
+          expect(subject.contents).to be_a(Pact::Term)
         end
+      end
+    end
 
-        describe "with an array where all elements should match by type and the rule is specified on both the parent element and the child elements" do
-          let(:expected) do
+    context "with an array where all elements should match by type and the rule is specified on the parent element and there is no min specified" do
+      let(:expected) do
+        {
+          'alligators' => [{'name' => 'Mary'}]
+        }
+      end
+
+      let(:matching_rules) do
+        {
+          "$.alligators" => {
+            "matchers" => [{ 'match' => 'type' }]
+          }
+        }
+      end
+
+      it "creates a Pact::SomethingLike at the appropriate path" do
+        expect(subject["alligators"]).to be_instance_of(Pact::SomethingLike)
+        expect(subject["alligators"].contents).to eq ['name' => 'Mary']
+      end
+    end
+
+    context "with an array where all elements should match by type and the rule is specified on the child elements" do
+      let(:expected) do
+        {
+          'alligators' => [{'name' => 'Mary'}]
+        }
+      end
+
+      let(:matching_rules) do
+        {
+          "$.alligators" => {
+            "matchers" => [{ 'min' => 2}]
+          },
+          "$.alligators[*].*" => {
+            "matchers" => [{ 'match' => 'type'}]
+          }
+        }
+      end
+
+      it "creates a Pact::ArrayLike at the appropriate path" do
+        expect(subject["alligators"]).to be_instance_of(Pact::ArrayLike)
+        expect(subject["alligators"].contents).to eq 'name' => 'Mary'
+        expect(subject["alligators"].min).to eq 2
+      end
+    end
+
+    context "with an array where all elements should match by type and the rule is specified on both the parent element and the child elements" do
+      let(:expected) do
+        {
+          'alligators' => [{'name' => 'Mary'}]
+        }
+      end
+
+      let(:matching_rules) do
+        {
+          "$.alligators" => {
+            "matchers" => [{ 'min' => 2, 'match' => 'type' }]
+          },
+          "$.alligators[*].*" => {
+            "matchers" => [{ 'match' => 'type' }]
+          }
+        }
+      end
+
+      it "creates a Pact::ArrayLike at the appropriate path" do
+        expect(subject["alligators"]).to be_instance_of(Pact::SomethingLike)
+        expect(subject["alligators"].contents).to be_instance_of(Pact::ArrayLike)
+        expect(subject["alligators"].contents.contents).to eq 'name' => 'Mary'
+        expect(subject["alligators"].contents.min).to eq 2
+      end
+    end
+
+    context "with an array where all elements should match by type and there is only a match:type on the parent element" do
+      let(:expected) do
+        {
+          'alligators' => [{'name' => 'Mary'}]
+        }
+      end
+
+      let(:matching_rules) do
+        {
+          "$.alligators" => { 'matchers' => [{'min' => 2, 'match' => 'type'}] }
+        }
+      end
+
+      it "creates a Pact::ArrayLike at the appropriate path" do
+        expect(subject["alligators"]).to be_instance_of(Pact::ArrayLike)
+        expect(subject["alligators"].contents).to eq 'name' => 'Mary'
+        expect(subject["alligators"].min).to eq 2
+      end
+    end
+
+    context "with an array where all elements should match by type nested inside another array where all elements should match by type" do
+      let(:expected) do
+        {
+
+          'alligators' => [
             {
-              'alligators' => [{'name' => 'Mary'}]
-            }
-          end
-
-          let(:matching_rules) do
-            {
-              "$.alligators" => {
-                "matchers" => [{ 'min' => 2, 'match' => 'type' }]
-              },
-              "$.alligators[*].*" => {
-                "matchers" => [{ 'match' => 'type' }]
-              }
-            }
-          end
-
-          it "creates a Pact::ArrayLike at the appropriate path" do
-            expect(subject["alligators"]).to be_instance_of(Pact::SomethingLike)
-            expect(subject["alligators"].contents).to be_instance_of(Pact::ArrayLike)
-            expect(subject["alligators"].contents.contents).to eq 'name' => 'Mary'
-            expect(subject["alligators"].contents.min).to eq 2
-          end
-        end
-
-        describe "with an array where all elements should match by type and there is only a match:type on the parent element" do
-          let(:expected) do
-            {
-              'alligators' => [{'name' => 'Mary'}]
-            }
-          end
-
-          let(:matching_rules) do
-            {
-              "$.alligators" => { 'matchers' => [{'min' => 2, 'match' => 'type'}] },
-            }
-          end
-
-          it "creates a Pact::ArrayLike at the appropriate path" do
-            expect(subject["alligators"]).to be_instance_of(Pact::ArrayLike)
-            expect(subject["alligators"].contents).to eq 'name' => 'Mary'
-            expect(subject["alligators"].min).to eq 2
-          end
-        end
-
-        describe "with an array where all elements should match by type nested inside another array where all elements should match by type" do
-          let(:expected) do
-            {
-
-              'alligators' => [
-                {
-                  'name' => 'Mary',
-                  'children' => [
-                    'age' => 9
-                  ]
-                }
+              'name' => 'Mary',
+              'children' => [
+                'age' => 9
               ]
-
             }
-          end
+          ]
 
-          let(:matching_rules) do
-            {
-              "$.alligators" => { "matchers" => [{ 'min' => 2, 'match' => 'type' }] },
-              "$.alligators[*].children" => { "matchers" => [{ 'min' => 1, 'match' => 'type' }]},
-            }
-          end
+        }
+      end
 
-          it "creates a Pact::ArrayLike at the appropriate path" do
-            expect(subject["alligators"].contents['children']).to be_instance_of(Pact::ArrayLike)
-            expect(subject["alligators"].contents['children'].contents).to eq 'age' => 9
-            expect(subject["alligators"].contents['children'].min).to eq 1
-          end
-        end
+      let(:matching_rules) do
+        {
+          "$.alligators" => { "matchers" => [{ 'min' => 2, 'match' => 'type' }] },
+          "$.alligators[*].children" => { "matchers" => [{ 'min' => 1, 'match' => 'type' }]}
+        }
+      end
 
-        describe "with an example array with more than one item" do
-          before do
-            allow($stderr).to receive(:puts)
-          end
+      it "creates a Pact::ArrayLike at the appropriate path" do
+        expect(subject["alligators"].contents['children']).to be_instance_of(Pact::ArrayLike)
+        expect(subject["alligators"].contents['children'].contents).to eq 'age' => 9
+        expect(subject["alligators"].contents['children'].min).to eq 1
+      end
+    end
 
-          let(:expected) do
-            {
+    context "with an example array with more than one item" do
+      before do
+        allow($stderr).to receive(:puts)
+      end
 
-              'alligators' => [
-                {'name' => 'Mary'},
-                {'name' => 'Joe'}
-              ]
+      let(:expected) do
+        {
 
-            }
-          end
+          'alligators' => [
+            {'name' => 'Mary'},
+            {'name' => 'Joe'}
+          ]
+        }
+      end
 
-          let(:matching_rules) do
-            {
-              "$.alligators" => { "matchers" => [{'min' => 2, 'match' => 'type'}] }
-            }
-          end
+      let(:matching_rules) do
+        {
+          "$.alligators" => { "matchers" => [{'min' => 2, 'match' => 'type'}] }
+        }
+      end
 
-          it "doesn't warn about the min size being ignored" do
-            expect(Pact.configuration.error_stream).to receive(:puts).once
-            subject
-          end
+      it "doesn't warn about the min size being ignored" do
+        subject
 
-          it "warns that the other items will be ignored" do
-            allow(Pact.configuration.error_stream).to receive(:puts)
-            expect(Pact.configuration.error_stream).to receive(:puts).with(/WARN: Only the first item/)
-            subject
-          end
-        end
+        expect(Pact.configuration.error_stream).to have_received(:puts).once
+      end
 
-        describe "using bracket notation for a Hash" do
-          let(:expected) do
-            {
-              "name" => "Mary"
-            }
-          end
+      it "warns that the other items will be ignored" do
+        allow(Pact.configuration.error_stream).to receive(:puts)
 
-          let(:matching_rules) do
-            {
-              "$['name']" => { "matchers" => [{"match" => "type"}] }
-            }
-          end
+        subject
 
-          it "applies the rule" do
-            expect(subject['name']).to be_instance_of(Pact::SomethingLike)
-          end
-        end
+        expect(Pact.configuration.error_stream).to have_received(:puts)
+          .with(/WARN: Only the first item/)
+      end
+    end
 
-        describe "with a dot in the path" do
-          let(:expected) do
-            {
-              "first.name" => "Mary"
-            }
-          end
+    context "using bracket notation for a Hash" do
+      let(:expected) do
+        {
+          "name" => "Mary"
+        }
+      end
 
-          let(:matching_rules) do
-            {
-              "$['first.name']" => { "matchers" => [{ "match" => "type" }] }
-            }
-          end
+      let(:matching_rules) do
+        {
+          "$['name']" => { "matchers" => [{ "match" => "type" }] }
+        }
+      end
 
-          it "applies the rule" do
-            expect(subject['first.name']).to be_instance_of(Pact::SomethingLike)
-          end
-        end
+      it "applies the rule" do
+        expect(subject['name']).to be_instance_of(Pact::SomethingLike)
+      end
+    end
 
-        describe "with an @ in the path" do
-          let(:expected) do
-            {
-              "@name" => "Mary"
-            }
-          end
+    describe "with a dot in the path" do
+      let(:expected) do
+        {
+          "first.name" => "Mary"
+        }
+      end
 
-          let(:matching_rules) do
-            {
-              "$['@name']" => { "matchers" => [ { "match" => "type" }] }
-            }
-          end
+      let(:matching_rules) do
+        {
+          "$['first.name']" => { "matchers" => [{ "match" => "type" }] }
+        }
+      end
 
-          it "applies the rule" do
-            expect(subject['@name']).to be_instance_of(Pact::SomethingLike)
-          end
-        end
+      it "applies the rule" do
+        expect(subject['first.name']).to be_instance_of(Pact::SomethingLike)
+      end
+    end
 
-        describe "with a combine key" do
-          let(:expected) do
-            {
-              "foo" => "bar"
-            }
-          end
+    context "with an @ in the path" do
+      let(:expected) do
+        {
+          "@name" => "Mary"
+        }
+      end
 
-          let(:matching_rules) do
-            {
-              "$.foo" => {
-                "matchers" => [{ "match" => "type" }],
-                "combine" => "AND"
-              }
-            }
+      let(:matching_rules) do
+        {
+          "$['@name']" => { "matchers" => [{ "match" => "type" }] }
+        }
+      end
 
-          end
+      it "applies the rule" do
+        expect(subject['@name']).to be_instance_of(Pact::SomethingLike)
+      end
+    end
 
-          it "logs the ignored rule" do
-            allow(Pact.configuration.error_stream).to receive(:puts)
-            expect(Pact.configuration.error_stream).to receive(:puts).with("WARN: Ignoring unsupported combine AND for path $['foo']")
-            subject
-          end
-        end
+    context "with a combine key" do
+      let(:expected) do
+        {
+          "foo" => "bar"
+        }
+      end
+
+      let(:matching_rules) do
+        {
+          "$.foo" => {
+            "matchers" => [{ "match" => "type" }],
+            "combine" => "AND"
+          }
+        }
+      end
+
+      it "logs the ignored rule" do
+        allow(Pact.configuration.error_stream).to receive(:puts)
+
+        subject
+
+        expect(Pact.configuration.error_stream).to have_received(:puts)
+          .with("WARN: Ignoring unsupported combine AND for path $['foo']")
       end
     end
   end


### PR DESCRIPTION
- Use compact class declaration to avoid unneeded deep indentation
- Use compound matchers when possible
- Use `context` instead of `describe` for state