### PR TITLE
Ruby 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.3.1
   - 2.4.3
   - 2.5.0
+  - 3.0.0
   - jruby-9.1.13.0
 gemfile:
   - gemfiles/default.gemfile


### PR DESCRIPTION
# Problem

We're working to support Ruby 3.0 and have run into some issues with this library. In particular with [this line](https://github.com/pact-foundation/pact-support/blob/575e49131f4d12fe90c5ece2e0f9abd6512c0a99/lib/pact/shared/active_support_support.rb#L30).

Here's a simple reproduction in `irb`.

```
iamvery/ruby-3 ~/C/O/pact-support » irb
irb(main):001:0/ r = //
=> //
irb(main):002:1* def r.as_json
irb(main):003:2* end
Traceback (most recent call last):
        4: from /Users/.../ruby/3.0.0/bin/irb:23:in `<main>'
        3: from /Users/.../ruby/3.0.0/bin/irb:23:in `load'
        2: from /Users/.../ruby/3.0.0/lib/ruby/gems/3.0.0/gems/irb-1.3.0/exe/irb:11:in `<top (required)>'
        1: from (irb):2:in `<main>'
FrozenError (can't modify frozen object: (?-mix:))
```

I was also able to reproduce this with your test suite. I was hoping to add Ruby 3.0 the build so that it's self-evident, but I don't see Travis being built on this PR. Here's an example from a local run:


```
1) Pact::ActiveSupportSupport fix_regexp returns the original regexp
     Failure/Error:
       def regexp.as_json options = {}
         {:json_class => 'Regexp', "o" => self.options, "s" => self.source }
       end

     FrozenError:
       can't modify frozen object: (?-mix:moose)
     # ./lib/pact/shared/active_support_support.rb:30:in `fix_regexp'
     # ./spec/lib/pact/consumer_contract/active_support_support_spec.rb:13:in `block (3 levels) in <module:Pact>'
     # ./spec/lib/pact/consumer_contract/active_support_support_spec.rb:16:in `block (3 levels) in <module:Pact>'
```