### PR TITLE
Initial support for specification v3 combined matchers

### DIFF
--- a/lib/pact/combined_match.rb
+++ b/lib/pact/combined_match.rb
@@ -1,0 +1,15 @@
+module Pact
+  
+  # Specifies that the actual object should be considered a match if
+  # it matches any of the matchers depending on combinator operation.
+
+  class CombinedMatch
+
+    attr_reader :combiner, :matchers
+
+    def initialize combiner, matchers
+      @combiner = combiner
+      @matchers = matchers
+    end
+  end
+end  


### PR DESCRIPTION
Hello, following the discussion here https://github.com/pact-foundation/pact-js/issues/51 I experimented with v3 `combine` matchers and it seems it can be used to implement optional types. 
As I'm not an expert in Ruby feel free to comment on style/logic. I will take care of tests and improvements later.
