### PR TITLE
fix: remove randexp dependency

### DIFF
--- a/lib/pact/reification.rb
+++ b/lib/pact/reification.rb
@@ -1,4 +1,4 @@
-require 'randomexp'
+require 'expgen'
 require 'pact/term'
 require 'pact/something_like'
 require 'pact/array_like'
@@ -13,8 +13,10 @@ module Pact
 
     def self.from_term(term)
       case term
-      when Pact::Term, Regexp, Pact::SomethingLike, Pact::ArrayLike
+      when Pact::Term, Pact::SomethingLike, Pact::ArrayLike
         from_term(term.generate)
+      when Regexp
+        from_term(Expgen.gen(term))
       when Hash
         term.inject({}) do |mem, (key,t)|
           mem[key] = from_term(t)

--- a/lib/pact/reification.rb
+++ b/lib/pact/reification.rb
@@ -1,4 +1,4 @@
-require 'expgen'
+require 'randomexp'
 require 'pact/term'
 require 'pact/something_like'
 require 'pact/array_like'
@@ -14,7 +14,7 @@ module Pact
     def self.from_term(term)
       case term
       when Pact::Term, Regexp, Pact::SomethingLike, Pact::ArrayLike
-        from_term(Expgen.gen(term))
+        from_term(term.generate)
       when Hash
         term.inject({}) do |mem, (key,t)|
           mem[key] = from_term(t)

--- a/lib/pact/reification.rb
+++ b/lib/pact/reification.rb
@@ -1,3 +1,4 @@
+require 'expgen'
 require 'pact/term'
 require 'pact/something_like'
 require 'pact/array_like'
@@ -13,7 +14,7 @@ module Pact
     def self.from_term(term)
       case term
       when Pact::Term, Regexp, Pact::SomethingLike, Pact::ArrayLike
-        from_term(term.generate)
+        from_term(Expgen.gen(term))
       when Hash
         term.inject({}) do |mem, (key,t)|
           mem[key] = from_term(t)

--- a/lib/pact/reification.rb
+++ b/lib/pact/reification.rb
@@ -1,4 +1,3 @@
-require 'randexp'
 require 'pact/term'
 require 'pact/something_like'
 require 'pact/array_like'

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "awesome_print", "~> 1.9"
   spec.add_runtime_dependency "diff-lcs", "~> 1.4"
 
+  spec.add_development_dependency 'expgen', '~> 0.1.1'
   spec.add_development_dependency "rspec", ">= 2.14", "< 4.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "webmock", "~> 3.3"

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "awesome_print", "~> 1.9"
   spec.add_runtime_dependency "diff-lcs", "~> 1.4"
 
-  spec.add_development_dependency 'randomexp', '~> 0.1.7'
+  spec.add_development_dependency 'expgen', '~> 0.1.1'
   spec.add_development_dependency "rspec", ">= 2.14", "< 4.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "webmock", "~> 3.3"

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files lib CHANGELOG.md LICENSE.txt README.md`.split($RS)
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "randexp", "~> 0.1.7"
   spec.add_runtime_dependency "term-ansicolor", "~> 1.0"
   spec.add_runtime_dependency "awesome_print", "~> 1.9"
   spec.add_runtime_dependency "diff-lcs", "~> 1.4"
 
+  spec.add_development_dependency "rspec", ">= 2.14", "< 4.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "webmock", "~> 3.3"
   spec.add_development_dependency "pry"

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "awesome_print", "~> 1.9"
   spec.add_runtime_dependency "diff-lcs", "~> 1.4"
 
-  spec.add_development_dependency "rspec", ">= 2.14", "< 4.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "webmock", "~> 3.3"
   spec.add_development_dependency "pry"

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "awesome_print", "~> 1.9"
   spec.add_runtime_dependency "diff-lcs", "~> 1.4"
 
-  spec.add_development_dependency 'expgen', '~> 0.1.1'
+  spec.add_development_dependency 'randomexp', '~> 0.1.7'
   spec.add_development_dependency "rspec", ">= 2.14", "< 4.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "webmock", "~> 3.3"


### PR DESCRIPTION
* Removing the randexp dependency.
* randexp is removed from pact in this PR - https://github.com/pact-foundation/pact-ruby/pull/202 
* Issue with the randexp is that it overrides the Array's pick method in this file - https://github.com/benburkert/randexp/blob/master/lib/randexp/core_ext/array.rb 
* This is causing issues with other unit tests which we have in our repo.

Testing:
* I have tested pact-support after removing the randexp from requirement and looks fine from my end. 