### PR TITLE
Fixup ruby warnings

### DIFF
--- a/lib/pact/consumer_contract/interaction_v2_parser.rb
+++ b/lib/pact/consumer_contract/interaction_v2_parser.rb
@@ -38,7 +38,7 @@ module Pact
       if query_is_string
         request_hash['query'] = Pact::QueryHash.new(request_hash['query'], original_query_string, Pact::Query.parsed_as_nested?(request_hash['query']))
       end
-      request = Pact::Request::Expected.from_hash(request_hash)
+      Pact::Request::Expected.from_hash(request_hash)
     end
 
     def self.parse_response response_hash, options

--- a/lib/pact/consumer_contract/pact_file.rb
+++ b/lib/pact/consumer_contract/pact_file.rb
@@ -35,7 +35,7 @@ module Pact
     def save_pactfile_to_tmp pact, name
       ::FileUtils.mkdir_p Pact.configuration.tmp_dir
       ::File.open(Pact.configuration.tmp_dir + "/#{name}", "w") { |file|  file << pact}
-    rescue Errno::EROFS => e
+    rescue Errno::EROFS
       # do nothing, probably on RunKit
     end
 
@@ -56,9 +56,9 @@ module Pact
     def get_remote_with_retry(uri_string, options)
       uri = URI(uri_string)
       if uri.userinfo
-		options[:username] = uri.user unless options[:username]
-		options[:password] = uri.password unless options[:password]
-	  end
+        options[:username] = uri.user unless options[:username]
+        options[:password] = uri.password unless options[:password]
+      end
       ((options[:retry_limit] || RETRY_LIMIT) + 1).times do |i|
         begin
           response = get_remote(uri, options)

--- a/lib/pact/matching_rules/merge.rb
+++ b/lib/pact/matching_rules/merge.rb
@@ -42,7 +42,7 @@ module Pact
       end
 
       def recurse_hash hash, path
-        recursed =  hash.each_with_object({}) do | (k, v), new_hash |
+        hash.each_with_object({}) do | (k, v), new_hash |
           new_path = path + "['#{k}']"
           new_hash[k] = recurse(v, new_path)
         end

--- a/lib/pact/term.rb
+++ b/lib/pact/term.rb
@@ -1,4 +1,5 @@
 require 'pact/shared/active_support_support'
+Regexp.remove_method(:as_json) if Regexp.method_defined?(:as_json)
 require 'json/add/regexp'
 require 'pact/errors'
 


### PR DESCRIPTION
```
…/json/add/regexp.rb:17: warning: method redefined; discarding old as_json
…/activesupport-7.0.2.3/lib/active_support/core_ext/object/json.rb:134: warning: previous definition of as_json was here
…/consumer_contract/interaction_v2_parser.rb:41: warning: assigned but unused variable - request
…/matching_rules/merge.rb:45: warning: assigned but unused variable - recursed
…/consumer_contract/pact_file.rb:39: warning: assigned but unused variable - e
…/consumer_contract/pact_file.rb:61: warning: mismatched indentations at 'end' with 'if' at 58
```