### PR TITLE
feat(generators): add generators to a consumer contract request

### DIFF
--- a/lib/pact/consumer_contract/request.rb
+++ b/lib/pact/consumer_contract/request.rb
@@ -6,7 +6,8 @@ module Pact
     class Expected < Pact::Request::Base
 
       DEFAULT_OPTIONS = {:allow_unexpected_keys => false}.freeze
-      attr_accessor :options #Temporary hack
+      attr_accessor :options, :generators #Temporary hack
+      
 
       def self.from_hash(hash)
         sym_hash = symbolize_keys hash
@@ -16,11 +17,13 @@ module Pact
         headers = sym_hash.fetch(:headers, key_not_found)
         body = sym_hash.fetch(:body, key_not_found)
         options = sym_hash.fetch(:options, {})
-        new(method, path, headers, body, query, options)
+        generators = sym_hash.fetch(:generators, {})
+        new(method, path, headers, body, query, options, generators)
       end
 
-      def initialize(method, path, headers, body, query, options = {})
+      def initialize(method, path, headers, body, query, options = {}, generators = {})
         super(method, path, headers, body, query)
+        @generators = generators
         @options = options
       end
 

--- a/lib/pact/consumer_contract/request.rb
+++ b/lib/pact/consumer_contract/request.rb
@@ -6,8 +6,7 @@ module Pact
     class Expected < Pact::Request::Base
 
       DEFAULT_OPTIONS = {:allow_unexpected_keys => false}.freeze
-      attr_accessor :options, :generators #Temporary hack
-      
+      attr_accessor :options, :generators
 
       def self.from_hash(hash)
         sym_hash = symbolize_keys hash

--- a/spec/lib/pact/consumer_contract/request_spec.rb
+++ b/spec/lib/pact/consumer_contract/request_spec.rb
@@ -48,8 +48,9 @@ module Pact
 
     describe "matching to actual requests" do
 
-      subject { Request::Expected.new(expected_method, expected_path, expected_headers, expected_body, expected_query, options) }
+      subject { Request::Expected.new(expected_method, expected_path, expected_headers, expected_body, expected_query, options, generators) }
       let(:options) { {} }
+      let(:generators) { {} }
 
       let(:expected_method) { 'get' }
       let(:expected_path) { '/foo' }


### PR DESCRIPTION
We want to parse generators part of the contract to support them in the verifier

Based on previous pull request  https://github.com/pact-foundation/pact-support/pull/79, added commit to address feedback