### PR TITLE
fix: enable color on non-tty if color_enabled

### DIFF
--- a/lib/pact/configuration.rb
+++ b/lib/pact/configuration.rb
@@ -6,6 +6,7 @@ require 'pact/shared/json_differ'
 require 'pact/shared/text_differ'
 require 'pact/shared/form_differ'
 require 'pact/shared/multipart_form_differ'
+require 'rainbow'
 
 
 module Pact
@@ -114,7 +115,9 @@ module Pact
 
     def color_enabled
       # Can't use ||= when the variable might be false, it will execute the expression if it's false
-      defined?(@color_enabled) ? @color_enabled : true
+      color_enabled = defined?(@color_enabled) ? @color_enabled : true
+      Rainbow.enabled = true if color_enabled
+      color_enabled
     end
 
     def color_enabled= color_enabled

--- a/spec/lib/pact/configuration_spec.rb
+++ b/spec/lib/pact/configuration_spec.rb
@@ -13,7 +13,7 @@ module Pact
         expect(subject.color_enabled).to be true
       end
 
-      it "allows configuration of colour_enabled" do
+      it "allows configuration of color_enabled" do
         subject.color_enabled = false
         expect(subject.color_enabled).to be false
       end


### PR DESCRIPTION
see https://github.com/ku1ik/rainbow\?tab\=readme-ov-file\#advanced-usage

preserves original behaviour of outputting color codes on non-tty/dumb terminals which caused failures in checking output when tested in gha via pact-ruby

relates to 

- https://github.com/pact-foundation/pact-support/pull/95
- https://github.com/pact-foundation/pact-ruby/pull/295
- https://github.com/pact-foundation/pact-ruby/pull/254

finally fixes the failure, which led to the revert of the change, and will finally allow us to remove the term-ansicolor dep from pact 👍🏾 