### PR TITLE
Lindomar reitz add support to match integers and floats

### DIFF
--- a/lib/pact/helpers.rb
+++ b/lib/pact/helpers.rb
@@ -47,12 +47,14 @@ module Pact
       Pact::Term.new(generate: date, matcher: /^\d{4}-[01]\d-[0-3]\d$/)
     end
 
+    # regex matched with pact-jvm 
+    # https://github.com/pact-foundation/pact-jvm/blob/00442e6df51e5be906ed470b19859246312e5c83/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt#L56-L59
     def like_integer int
-      Pact::Term.new(generate: int, matcher: /[0-9]/)
+      Pact::Term.new(generate: int, matcher: /^-?\d+$/)
     end
 
     def like_decimal float
-      Pact::Term.new(generate: float, matcher: /[-+]?([0-9]*\.[0-9]+|[0-9]+)/)
+      Pact::Term.new(generate: float, matcher: /^0|-?\d+\.\d*$/)
     end
 
     def like_datetime_rfc822 datetime

--- a/lib/pact/helpers.rb
+++ b/lib/pact/helpers.rb
@@ -47,6 +47,14 @@ module Pact
       Pact::Term.new(generate: date, matcher: /^\d{4}-[01]\d-[0-3]\d$/)
     end
 
+    def like_integer int
+      Pact::Term.new(generate: int, matcher: /[0-9]/)
+    end
+
+    def like_decimal float
+      Pact::Term.new(generate: float, matcher: /[-+]?([0-9]*\.[0-9]+|[0-9]+)/)
+    end
+
     def like_datetime_rfc822 datetime
       Pact::Term.new(
         generate: datetime,

--- a/lib/pact/matchers/matchers.rb
+++ b/lib/pact/matchers/matchers.rb
@@ -78,7 +78,7 @@ module Pact
       if term.matcher.match(actual)
         NO_DIFF
       else
-        RegexpDifference.new term.matcher, options[:original] ||= actual, "Expected a #{options[:was_float] ? "Float" : options[:was_int] ? "Integer" : "String" } matching #{term.matcher.inspect} (like #{term.generate.inspect}) but got #{options[:was_float] || options[:was_int] ? class_name_with_value_in_brackets(options[:original]) : actual.inspect} at <path>"
+        RegexpDifference.new term.matcher, options[:original] ||= actual, "Expected a Value matching #{term.matcher.inspect} (like #{term.generate.inspect}) but got #{options[:was_float] || options[:was_int] ? class_name_with_value_in_brackets(options[:original]) : actual.inspect} at <path>"
       end
     end
 

--- a/lib/pact/matchers/matchers.rb
+++ b/lib/pact/matchers/matchers.rb
@@ -61,6 +61,12 @@ module Pact
     alias_method :structure_diff, :type_diff # Backwards compatibility
 
     def term_diff term, actual, options
+      if actual.is_a?(Float) || actual.is_a?(Integer)
+        options[:original] = actual
+        options[:was_float] = actual.is_a?(Float)
+        options[:was_int] = actual.is_a?(Integer)
+        actual = actual.to_s
+      end
       if actual.is_a?(String)
         actual_term_diff term, actual, options
       else
@@ -72,7 +78,7 @@ module Pact
       if term.matcher.match(actual)
         NO_DIFF
       else
-        RegexpDifference.new term.matcher, actual, "Expected a String matching #{term.matcher.inspect} (like #{term.generate.inspect}) but got #{actual.inspect} at <path>"
+        RegexpDifference.new term.matcher, options[:original] ||= actual, "Expected a #{options[:was_float] ? "Float" : options[:was_int] ? "Integer" : "String" } matching #{term.matcher.inspect} (like #{term.generate.inspect}) but got #{options[:was_float] || options[:was_int] ? class_name_with_value_in_brackets(options[:original]) : actual.inspect} at <path>"
       end
     end
 

--- a/lib/pact/term.rb
+++ b/lib/pact/term.rb
@@ -26,12 +26,14 @@ module Pact
 
     def initialize(attributes = {})
       @generate = attributes[:generate]
-      raise Pact::Error.new("Please specify a value to generate for the Term") unless @generate != nil
-
-      @generate = @generate.to_s 
       @matcher = attributes[:matcher]
       raise Pact::Error.new("Please specify a matcher for the Term") unless @matcher != nil
-      raise Pact::Error.new("Value to generate '#{@generate}' does not match regular expression #{@matcher.inspect}") unless @generate =~ @matcher
+      raise Pact::Error.new("Please specify a value to generate for the Term") unless @generate != nil
+      if @generate.is_a?(Float) || @generate.is_a?(Integer)
+        raise Pact::Error.new("#{@generate.is_a?(Float) ? "Float" : "Integer"} Value to generate '#{@generate}' does not match regular expression #{@matcher.inspect} when converted to string") unless @generate.to_s =~ @matcher
+      else
+        raise Pact::Error.new("Value to generate '#{@generate}' does not match regular expression #{@matcher.inspect}") unless @generate =~ @matcher
+      end
     end
 
     def to_hash

--- a/spec/lib/pact/helpers_spec.rb
+++ b/spec/lib/pact/helpers_spec.rb
@@ -139,5 +139,26 @@ module Pact
 
       end
     end
+
+    describe "#like_integer" do
+      let(:integer) { 1 }
+
+      it "creates a Pact::Term with regex matcher for integers" do
+        expect(like_integer(integer)).to eq Pact::Term.new(
+          generate: integer,
+          matcher: /[0-9]/
+        )
+      end
+    end
+    describe "#like_decimal" do
+      let(:float) { 10.2 }
+
+      it "creates a Pact::Term with regex matcher for decimals" do
+        expect(like_decimal(10.2)).to eq Pact::Term.new(
+          generate: float,
+          matcher: /[-+]?([0-9]*\.[0-9]+|[0-9]+)/
+        )
+      end
+    end
   end
 end

--- a/spec/lib/pact/helpers_spec.rb
+++ b/spec/lib/pact/helpers_spec.rb
@@ -146,7 +146,7 @@ module Pact
       it "creates a Pact::Term with regex matcher for integers" do
         expect(like_integer(integer)).to eq Pact::Term.new(
           generate: integer,
-          matcher: /[0-9]/
+          matcher: /^-?\d+$/
         )
       end
     end
@@ -156,7 +156,7 @@ module Pact
       it "creates a Pact::Term with regex matcher for decimals" do
         expect(like_decimal(10.2)).to eq Pact::Term.new(
           generate: float,
-          matcher: /[-+]?([0-9]*\.[0-9]+|[0-9]+)/
+          matcher: /^0|-?\d+\.\d*$/
         )
       end
     end

--- a/spec/lib/pact/matchers/matchers_messages_regexp_spec.rb
+++ b/spec/lib/pact/matchers/matchers_messages_regexp_spec.rb
@@ -27,21 +27,21 @@ module Pact::Matchers
 
         context "when the Pact::Term does not match" do
           it "returns a message" do
-            expect(difference[:thing].message).to eq "Expected a String matching /foo/ (like \"food\") but got \"drink\" at <path>"
+            expect(difference[:thing].message).to eq "Expected a Value matching /foo/ (like \"food\") but got \"drink\" at <path>"
           end
         end
 
         context "when the actual is a numeric" do
           let(:actual) { INT }
           it "returns a message" do
-            expect(difference[:thing].message).to eq "Expected a Integer matching /foo/ (like \"food\") but got #{a_numeric} (1) at <path>"
+            expect(difference[:thing].message).to eq "Expected a Value matching /foo/ (like \"food\") but got #{a_numeric} (1) at <path>"
           end
         end
 
         context "when the actual is a float" do
           let(:actual) { FLOAT }
           it "returns a message" do
-            expect(difference[:thing].message).to eq "Expected a Float matching /foo/ (like \"food\") but got #{a_float} (1.0) at <path>"
+            expect(difference[:thing].message).to eq "Expected a Value matching /foo/ (like \"food\") but got #{a_float} (1.0) at <path>"
           end
         end
 
@@ -49,20 +49,6 @@ module Pact::Matchers
           let(:actual) { HASH }
           it "returns a message" do
             expect(difference[:thing].message).to eq "Expected a String matching /foo/ (like \"food\") but got a Hash at <path>"
-          end
-        end
-
-        context "when the actual is a numeric" do
-          let(:actual) { INT }
-          it "returns a message" do
-            expect(difference[:thing].message).to eq "Expected a Integer matching /foo/ (like \"food\") but got #{a_numeric} (1) at <path>"
-          end
-        end
-
-        context "when the actual is a float" do
-          let(:actual) { FLOAT }
-          it "returns a message" do
-            expect(difference[:thing].message).to eq "Expected a Float matching /foo/ (like \"food\") but got #{a_float} (1.0) at <path>"
           end
         end
 

--- a/spec/lib/pact/matchers/matchers_messages_regexp_spec.rb
+++ b/spec/lib/pact/matchers/matchers_messages_regexp_spec.rb
@@ -34,7 +34,14 @@ module Pact::Matchers
         context "when the actual is a numeric" do
           let(:actual) { INT }
           it "returns a message" do
-            expect(difference[:thing].message).to eq "Expected a String matching /foo/ (like \"food\") but got #{a_numeric} (1) at <path>"
+            expect(difference[:thing].message).to eq "Expected a Integer matching /foo/ (like \"food\") but got #{a_numeric} (1) at <path>"
+          end
+        end
+
+        context "when the actual is a float" do
+          let(:actual) { FLOAT }
+          it "returns a message" do
+            expect(difference[:thing].message).to eq "Expected a Float matching /foo/ (like \"food\") but got #{a_float} (1.0) at <path>"
           end
         end
 
@@ -48,7 +55,14 @@ module Pact::Matchers
         context "when the actual is a numeric" do
           let(:actual) { INT }
           it "returns a message" do
-            expect(difference[:thing].message).to eq "Expected a String matching /foo/ (like \"food\") but got #{a_numeric} (1) at <path>"
+            expect(difference[:thing].message).to eq "Expected a Integer matching /foo/ (like \"food\") but got #{a_numeric} (1) at <path>"
+          end
+        end
+
+        context "when the actual is a float" do
+          let(:actual) { FLOAT }
+          it "returns a message" do
+            expect(difference[:thing].message).to eq "Expected a Float matching /foo/ (like \"food\") but got #{a_float} (1.0) at <path>"
           end
         end
 

--- a/spec/lib/pact/term_spec.rb
+++ b/spec/lib/pact/term_spec.rb
@@ -23,7 +23,7 @@ module Pact
         end
 
         context "when the generate is a float" do
-          let(:term) { Term.new(generate: 50.51, matcher: /\d(\.\d{1,2})/)}
+          let(:term) { Term.new(generate: 50.51, matcher: /[-+]?([0-9]*\.[0-9]+|[0-9]+)/)}
 
           it 'does not raise an exception' do
             term

--- a/spec/lib/pact/term_spec.rb
+++ b/spec/lib/pact/term_spec.rb
@@ -15,19 +15,19 @@ module Pact
         end
 
         context "when the generate is a integer" do
-          let(:term) { Term.new(generate: 10, matcher: /[0-9]/)} 
+          let(:term) { Term.new(generate: 10, matcher: /[0-9]/)}
 
           it 'does not raise an exception' do
             term
-          end 
+          end
         end
-        
+
         context "when the generate is a float" do
-          let(:term) { Term.new(generate: 50.51, matcher: /\d(\.\d{1,2})/)} 
+          let(:term) { Term.new(generate: 50.51, matcher: /\d(\.\d{1,2})/)}
 
           it 'does not raise an exception' do
             term
-          end 
+          end
         end
 
         context "when the matcher does not match the generated value" do

--- a/spec/lib/pact/term_spec.rb
+++ b/spec/lib/pact/term_spec.rb
@@ -15,7 +15,7 @@ module Pact
         end
 
         context "when the generate is a integer" do
-          let(:term) { Term.new(generate: 10, matcher: /[0-9]/)}
+          let(:term) { Term.new(generate: 10, matcher: /^-?\d+$/)}
 
           it 'does not raise an exception' do
             term
@@ -23,7 +23,7 @@ module Pact
         end
 
         context "when the generate is a float" do
-          let(:term) { Term.new(generate: 50.51, matcher: /[-+]?([0-9]*\.[0-9]+|[0-9]+)/)}
+          let(:term) { Term.new(generate: 50.51, matcher: /^0|-?\d+\.\d*$/)}
 
           it 'does not raise an exception' do
             term

--- a/spec/support/ruby_version_helpers.rb
+++ b/spec/support/ruby_version_helpers.rb
@@ -20,4 +20,8 @@ module RubyVersionHelpers
     end
   end
   module_function :a_numeric
+  def a_float
+    "a #{Float}"
+  end
+  module_function :a_float
 end


### PR DESCRIPTION
continuation of #38 

fixes #13 by utilising regex string from [pact-jvm](https://github.com/pact-foundation/pact-jvm/blob/master/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt#L56-L59)

notes from previous PR

- on consumer side, pact.term allowed int and float(decimal) value, with the value changed to a string (which is stored in the pact file)
- on the provider side, int and float(decimal) values returned from the consumer, were not transformed into strings for comparison against the specified term regex.

This updated change will allow int/float(decimal) values to be changed to string at the point of comparison against the regex, both during consumer and provider tests.

On the provider side, if the value is a float or string, the error message returned returns the object type in the message.

With regard to existing behaviour, it may also be noted that using `Pact.like(1)` or `Pact.like(50.51)` will serialising the correct value to the contract (int or float) however the provider test would pass with a type match, when the provider returns `50` and the consumer set `Pact.like(50.51)`.

## Integer

```
Term.new(generate: 10, matcher: /[0-9]/
```

## Float / Decimal 

```
Term.new(generate: 50.51, matcher: /\d(\.\d{1,2})/)
```
