### PR TITLE
fix: add blank lines to empty hashs - json 2.8.x regression

### DIFF
--- a/lib/pact/matchers/unix_diff_formatter.rb
+++ b/lib/pact/matchers/unix_diff_formatter.rb
@@ -63,6 +63,7 @@ module Pact
           # Can't think of an elegant way to check if we can pretty generate other than to try it and maybe fail
           json = fix_blank_lines_in_empty_hashes JSON.pretty_generate(comparable)
           json = add_blank_lines_in_empty_hashes json
+          json = add_blank_lines_in_empty_arrays json
           add_comma_to_end_of_arrays json
         rescue JSON::GeneratorError
           comparable.to_s

--- a/lib/pact/matchers/unix_diff_formatter.rb
+++ b/lib/pact/matchers/unix_diff_formatter.rb
@@ -62,6 +62,7 @@ module Pact
         begin
           # Can't think of an elegant way to check if we can pretty generate other than to try it and maybe fail
           json = fix_blank_lines_in_empty_hashes JSON.pretty_generate(comparable)
+          json = add_blank_lines_in_empty_hashes json
           add_comma_to_end_of_arrays json
         rescue JSON::GeneratorError
           comparable.to_s

--- a/lib/pact/shared/jruby_support.rb
+++ b/lib/pact/shared/jruby_support.rb
@@ -14,5 +14,11 @@ module Pact
       json.gsub(/({\n)\n(\s*})/,'\1\2')
     end
 
+    # formatting changes when using json 2.8.x
+    # in ruby 3.x +
+    # brought in by faraday 2.12.0
+    def add_blank_lines_in_empty_hashes(json)
+      json.gsub(/({\s*})/, "{\n  }")
+    end
   end
 end

--- a/lib/pact/shared/jruby_support.rb
+++ b/lib/pact/shared/jruby_support.rb
@@ -14,11 +14,14 @@ module Pact
       json.gsub(/({\n)\n(\s*})/,'\1\2')
     end
 
-    # formatting changes when using json 2.8.x
-    # in ruby 3.x +
-    # brought in by faraday 2.12.0
+    # preserve pre json 2.8.x behaviour
+    # https://github.com/ruby/json/pull/626
     def add_blank_lines_in_empty_hashes(json)
       json.gsub(/({\s*})/, "{\n  }")
+    end
+
+    def add_blank_lines_in_empty_arrays(json)
+      json.gsub(/\[\s*\]/, "[\n  ]")
     end
   end
 end

--- a/spec/lib/pact/matchers/unix_diff_formatter_spec.rb
+++ b/spec/lib/pact/matchers/unix_diff_formatter_spec.rb
@@ -123,6 +123,7 @@ EOF
           end
 
           it "generates the right number of lines, even with ActiveSupport loaded" do
+            puts subject
             expect(line_count).to eq 7 + key_lines_count
           end
         end


### PR DESCRIPTION
json 2.8.0+ no longer prints empty hashs over new lines, so we now get this output

```
Diff
--------------------------------------
Key: - is expected 
     + is actual 
Matching keys and values are not shown

 {
-  "thing": {
-    "alligator": {
-      "name": "Mary"
-    }
-  }
+  "thing": {}
 }

Description of differences
--------------------------------------
```

compared to the expected

```
Diff
--------------------------------------
Key: - is expected 
     + is actual 
Matching keys and values are not shown

 {
   "thing": {
-    "alligator": {
-      "name": "Mary"
-    }
   }
 }

Description of differences
--------------------------------------

      generates the right number of lines, even with ActiveSupport loaded

Finished in 0.00154 seconds (files took 0.42989 seconds to load)
1 example, 0 failures

```

Interestingly it only fails on Ruby 3.x+ with [json 2.8.x gem](https://github.com/ruby/json/releases/tag/v2.8.0), which is pulled in by the faraday change when pinned [here](https://github.com/lostisland/faraday/pull/1589/files) as part of [2.12.0 ](https://github.com/lostisland/faraday/compare/v2.11.0...v2.12.0)release