### PR TITLE
Fix for generation of invalid json

### DIFF
--- a/lib/pact/shared/active_support_support.rb
+++ b/lib/pact/shared/active_support_support.rb
@@ -66,9 +66,9 @@ module Pact
     private
 
     def fix_empty_hash_and_array json
-      json = json.gsub(/({\s*})/, "{\n        }")
-      json.gsub(/\[\s*\]/, "[\n        ]")
       json
+        .gsub(/({\s*})(?=,?$)/, "{\n        }")
+        .gsub(/\[\s*\](?=,?$)/, "[\n        ]")
     end
   end
 end

--- a/spec/lib/pact/consumer_contract/active_support_support_spec.rb
+++ b/spec/lib/pact/consumer_contract/active_support_support_spec.rb
@@ -77,6 +77,41 @@ module Pact
       it "pretty formats the json that has been not pretty formatted because of ActiveSupport" do
         expect(fix_json_formatting(active_support_affected_pretty_generated_json)).to eq (pretty_generated_json.strip)
       end
+
+      context 'when the JSON includes empty arrays or hashes in a compact format' do
+        let(:active_support_affected_pretty_generated_json) do
+'{
+  "empty_hash": {},
+  "empty_array": []
+}'
+        end
+        let(:pretty_generated_json) do
+'{
+  "empty_hash": {
+        },
+  "empty_array": [
+        ]
+}'
+        end
+
+        it "expands the empty hash/array to be multiline" do
+          expect(fix_json_formatting(active_support_affected_pretty_generated_json)).to eq(pretty_generated_json.strip)
+        end
+      end
+
+      context 'when the JSON includes json-like strings inside' do
+        let(:pretty_generated_json) do
+'{
+  "not_really_an_empty_hash": "{}",
+  "not_really_an_empty_array": "[]"
+}'
+        end
+
+        it 'does not change the inner strings' do
+          expect(fix_json_formatting(pretty_generated_json)).to eq(pretty_generated_json)
+        end
+
+      end
     end
   end
 end


### PR DESCRIPTION
Seems like the fix introduced in https://github.com/pact-foundation/pact-support/commit/f54a97c93fdaa3bd769b8963e290358143862070 has a couple of issues:

* It doesn't insert the newline for arrays
* It inserts newlines when it finds `{}` or `[]` inside a string in the json document, which makes it an invalid document.

We've ran into the second issue, it's preventing us from upgrading since some of our pipelines fail.

The solution is hacky, it relies on the json being pretty formatted. In that case each line should have a single value, and the `{}` or `[]`, with an extra `,` should be the last content in the line.

```json
{
  "empty_array": [],
  "other": {
    "more": "fields"
  },
  "empty_hash": {}
}
```
