### PR TITLE
chore(ci): prevent duplicate ci triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
Triggering on all 'push' and 'pull_request' events will result in duplicated CI runs in PRs (due to both conditions being met).

Instead, trigger only on pushes to `master`, or updates to PRs targetting `master`.