### PR TITLE
chore: update gems and fix specs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ Gemfile.lock
 gemfiles/*.lock
 spec/examples.txt
 .byebug_history
+.tool-versions
 
 .DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 group :test do
   gem 'faraday', '~> 2.0'
   gem 'faraday-retry', '~> 2.0'
-  gem 'webrick', '~> 1.8'
-  gem 'rack', '~> 2.2'
+  gem 'webrick', '~> 1.9.1'
+  gem 'rack', '~> 3.0'
+  gem 'rackup'
 end

--- a/lib/pact/consumer_contract/consumer_contract.rb
+++ b/lib/pact/consumer_contract/consumer_contract.rb
@@ -48,7 +48,7 @@ module Pact
     end
 
     def self.from_json string
-      deserialised_object = JSON.load(maintain_backwards_compatiblity_with_producer_keys(string))
+      deserialised_object = JSON.unsafe_load(maintain_backwards_compatiblity_with_producer_keys(string))
       from_hash(deserialised_object)
     end
 

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rainbow", "~> 3.1.1"
   spec.add_runtime_dependency "awesome_print", "~> 1.9"
-  spec.add_runtime_dependency "diff-lcs", "~> 1.5"
+  spec.add_runtime_dependency "diff-lcs", "~> 1.6"
   spec.add_runtime_dependency "expgen", "~> 0.1"
   spec.add_runtime_dependency 'string_pattern', '~> 2.0'
   spec.add_runtime_dependency 'jsonpath', '~> 1.0'

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'string_pattern', '~> 2.0'
   spec.add_runtime_dependency 'jsonpath', '~> 1.0'
   spec.add_runtime_dependency 'json', '~> 2.12.2'
+  spec.add_development_dependency "stringio", "~> 3"
 
   spec.add_development_dependency "rspec", ">= 2.14", "< 4.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "expgen", "~> 0.1"
   spec.add_runtime_dependency 'string_pattern', '~> 2.0'
   spec.add_runtime_dependency 'jsonpath', '~> 1.0'
+  spec.add_runtime_dependency 'json', '~> 2.12.2'
 
   spec.add_development_dependency "rspec", ">= 2.14", "< 4.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/spec/lib/pact/matchers/differ_spec.rb
+++ b/spec/lib/pact/matchers/differ_spec.rb
@@ -31,7 +31,7 @@ module Pact
  this
  is
  soo
-@@ -9,6 +9,5 @@
+@@ -9,5 +9,4 @@
  equal
  insert
  a
@@ -86,7 +86,7 @@ EOD
 
           expected_diff = <<'EOD'
 
-@@ -1,5 +1,5 @@
+@@ -1,4 +1,4 @@
  <Animal
    name=bob,
 -  species=tortoise
@@ -105,7 +105,7 @@ EOD
           expected_diff = <<'EOD'
 
 
-@@ -5,7 +5,7 @@
+@@ -5,6 +5,6 @@
   :metasyntactic,
   "variable",
   :delta,
@@ -182,7 +182,7 @@ EOD
 
           expected_diff = <<'EOD'
 
-@@ -1,3 +1,3 @@
+@@ -1,2 +1,2 @@
  this is:
 -  another string
 +  one string

--- a/spec/support/ssl_server.rb
+++ b/spec/support/ssl_server.rb
@@ -8,6 +8,7 @@ if __FILE__ == $0
     @server.shutdown
     exit
   end
+  require 'stringio'
 
   def webrick_opts port
     certificate = OpenSSL::X509::Certificate.new(File.read(SSL_CERT))
@@ -32,11 +33,11 @@ if __FILE__ == $0
   require "webrick"
   require "webrick/https"
   require "rack"
-  require "rack/handler/webrick"
+  require "rackup/handler/webrick"
 
   opts = webrick_opts(4444)
 
-  Rack::Handler::WEBrick.run(app, **opts) do |server|
+  Rackup::Handler::WEBrick.run(app, **opts) do |server|
     @server = server
   end
 end


### PR DESCRIPTION
Changes in the JSON.load are causing downstream deprecation warnings.  
- updated json gem previously not specficied.
- updated rack3 for tests
- fixed spec diffs around position offsets. Perhaps naive but fails in master and current release.
- bumped diff-lcs to latest