### PR TITLE
fix: use the safe json load to fix deprecation warnings.

### DIFF
--- a/lib/pact/consumer_contract/consumer_contract.rb
+++ b/lib/pact/consumer_contract/consumer_contract.rb
@@ -48,7 +48,10 @@ module Pact
     end
 
     def self.from_json string
-      deserialised_object = JSON.unsafe_load(maintain_backwards_compatiblity_with_producer_keys(string))
+      deserialised_object = JSON.load(
+        maintain_backwards_compatiblity_with_producer_keys(string),
+        nil, { create_additions: false }
+      )
       from_hash(deserialised_object)
     end
 


### PR DESCRIPTION
follow up to yesterdays fixes. uses the safer json load with options. 