### PR TITLE
Replace awesome_print with amazing_print #122

### DIFF
--- a/lib/pact/matchers/list_diff_formatter.rb
+++ b/lib/pact/matchers/list_diff_formatter.rb
@@ -1,4 +1,4 @@
-require 'awesome_print' # The .ai method comes from awesome_print
+require 'amazing_print' # The .ai method comes from awesome_print
 
 module Pact
   module Matchers

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/pact-foundation/pact-support"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.files         = `git ls-files lib CHANGELOG.md LICENSE.txt README.md`.split($RS)
   spec.require_paths = ["lib"]

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rainbow", "~> 3.1.1"
-  spec.add_runtime_dependency "awesome_print", "~> 1.9"
+  spec.add_runtime_dependency "amazing_print", "~> 1.8"
   spec.add_runtime_dependency "diff-lcs", "~> 1.6"
   spec.add_runtime_dependency "expgen", "~> 0.1"
   spec.add_runtime_dependency 'string_pattern', '~> 2.0'

--- a/spec/lib/pact/matchers/list_diff_formatter_spec.rb
+++ b/spec/lib/pact/matchers/list_diff_formatter_spec.rb
@@ -5,7 +5,7 @@ require 'support/ruby_version_helpers'
 
 # Needed to stop the ai printing in color
 # TODO: fix this!
-AwesomePrint.defaults = {
+AmazingPrint.defaults = {
   plain: true
 }
 


### PR DESCRIPTION
Replaced awesome_print dependency and usage with amazing_print across the codebase.

- Updated `pact-support.gemspec` to use `amazing_print` instead of `awesome_print`
- Adjusted formatting in `lib/pact/matchers/list_diff_formatter.rb`
- Updated tests in `spec/lib/pact/matchers/list_diff_formatter_spec.rb` accordingly